### PR TITLE
feat: approve only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+on: pull_request
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v1.1.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          approve-only: true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
 # Github Action Merge Dependabot
 
-This action automatically merges dependabot PRs.
+This action automatically approves and merges dependabot PRs.
 
 ## Inputs
 
 ### `github-token`
 
-**Required** A github token.
+**Required** A GitHub token.
 
 ### `exclude`
 
-*Optional* An array of packages that you don't want to auto-merge and would like to manually review to decide whether to upgrade or not.
+_Optional_ An array of packages that you don't want to auto-merge and would like to manually review to decide whether to upgrade or not.
+
+### `approve-only`
+
+_Optional_ If `true`, the PR is only approved but not merged. Defaults to `false`.
 
 ### `merge-method`
 
-*Optional* The merge method you would like to use (squash, merge, rebase). Default to `squash` merge.
+_Optional_ The merge method you would like to use (squash, merge, rebase). Default to `squash` merge.
 
 ### `merge-comment`
 
-*Optional* An arbitrary message that you'd like to comment on the PR after it gets auto-merged. This is only useful when you're recieving too much of noise in email and would like to filter mails for PRs that got automatically merged.
+_Optional_ An arbitrary message that you'd like to comment on the PR after it gets auto-merged. This is only useful when you're recieving too much of noise in email and would like to filter mails for PRs that got automatically merged.
 
 ## Example usage
 
@@ -29,8 +33,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      ...
+    steps: # ...
 
   automerge:
     needs: build
@@ -39,23 +42,22 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v1
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
-          github-token: ${{secrets.github_token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
 ```
 
 **Note**
 
-- The `github_token` is automatically provided by Github Actions, which we access using `secrets.github_token` and supply to the action as an input `github-token`.
+- The GitHub token is automatically provided by Github Actions, which we access using `secrets.GITHUB_TOKEN` and supply to the action as an input `github-token`.
+- This action must be used in the context of a Pull Request. If the workflow can be triggered by other events (e.g. push), make sure to include `github.event_name == 'pull_request'` in the action conditions, as shown in the example.
 - Make sure to use `needs: <jobs>` to delay the auto-merging until CI checks (test/build) are passed.
 
 ## With `exclude`
 
 ```yml
-...
-    steps:
-      - uses: fastify/github-action-merge-dependabot@v1
-        if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
-        with:
-          github-token: ${{secrets.github_token}}
-          exclude: ['material-ui']
-...
+steps:
+  - uses: fastify/github-action-merge-dependabot@v1
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
+    with:
+      github-token: ${{secrets.github_token}}
+      exclude: ['react']
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,16 @@
 name: "Github Action Merge Dependabot"
-description: "Automatically merge dependabot PRs"
+description: "Automatically approve and merge dependabot PRs"
 inputs:
   github-token:
-    description: "A GitHub token."
+    description: "A GitHub token"
     required: true
   exclude:
     description: "Packages that you want to manually review before upgrading"
     required: false
+  approve-only:
+    description: "If true, the PR is only approved but not merged"
+    required: false
+    default: false
   merge-method:
     description: "The merge method you would like to use (squash, merge, rebase)"
     required: false

--- a/src/util.js
+++ b/src/util.js
@@ -23,5 +23,6 @@ exports.getInputs = () => ({
   GITHUB_TOKEN: core.getInput('github-token', { required: true }),
   MERGE_METHOD: getMergeMethod(),
   EXCLUDE_PKGS: core.getInput('exclude') || [],
-  MERGE_COMMENT: core.getInput('merge-comment') || ''
+  MERGE_COMMENT: core.getInput('merge-comment') || '',
+  APPROVE_ONLY: core.getInput('approve-only')
 })


### PR DESCRIPTION
Because of https://github.com/fastify/github-action-merge-dependabot/issues/8, we need a different way to run builds when dependabot PRs are merged.

GitHub now has an automerge option in the repository settings, which allows merging a PR when requirements are satisfied. Those requirements usually include:

- a green build
- one approval

This feature allows this action to only provide the approval without merging, so that we can use the built-in GH feature to do the merge and run the CI checks instead.

It's clearly not exactly the same thing, because using GH's automerge would automerge other PRs besides the dependabot ones, but it's good enough.

Closes #8 