### PR TITLE
ci: notify non generated dist on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Detect Generation needed Dist
         run: |
           npm run build
-          git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." || echo "Changes detected. Please run npm run build" && exit 1
+          git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." && exit 0 \
+           || echo "Changes detected. Please run npm run build" && exit 1
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test
+      - name: Detect Generation needed Dist
+        run: |
+          npm run build
+          git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." || echo "Changes detected. Please run npm run build"
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Detect Generation needed Dist
         run: |
           npm run build
-          git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." || echo "Changes detected. Please run npm run build"
+          git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." || echo "Changes detected. Please run npm run build" && exit 1
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - name: Detect Generation needed Dist
-        if: github.actor != 'dependabot'
+        if: github.actor != 'dependabot' && github.event_name == 'pull_request'
         run: |
           npm run build
           git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." && exit 0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - name: Detect Generation needed Dist
+        if: github.actor != 'dependabot'
         run: |
           npm run build
           git diff --exit-code --quiet ./dist && echo "No changes detected. Ok." && exit 0 \

--- a/dist/index.js
+++ b/dist/index.js
@@ -6789,7 +6789,7 @@ module.exports = eval("require")("encoding");
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("assert");;
+module.exports = require("assert");
 
 /***/ }),
 
@@ -6797,7 +6797,7 @@ module.exports = require("assert");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("events");;
+module.exports = require("events");
 
 /***/ }),
 
@@ -6805,7 +6805,7 @@ module.exports = require("events");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("fs");;
+module.exports = require("fs");
 
 /***/ }),
 
@@ -6813,7 +6813,7 @@ module.exports = require("fs");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("http");;
+module.exports = require("http");
 
 /***/ }),
 
@@ -6821,7 +6821,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("https");;
+module.exports = require("https");
 
 /***/ }),
 
@@ -6829,7 +6829,7 @@ module.exports = require("https");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("net");;
+module.exports = require("net");
 
 /***/ }),
 
@@ -6837,7 +6837,7 @@ module.exports = require("net");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("os");;
+module.exports = require("os");
 
 /***/ }),
 
@@ -6845,7 +6845,7 @@ module.exports = require("os");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("path");;
+module.exports = require("path");
 
 /***/ }),
 
@@ -6853,7 +6853,7 @@ module.exports = require("path");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("stream");;
+module.exports = require("stream");
 
 /***/ }),
 
@@ -6861,7 +6861,7 @@ module.exports = require("stream");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("tls");;
+module.exports = require("tls");
 
 /***/ }),
 
@@ -6869,7 +6869,7 @@ module.exports = require("tls");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("url");;
+module.exports = require("url");
 
 /***/ }),
 
@@ -6877,7 +6877,7 @@ module.exports = require("url");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("util");;
+module.exports = require("util");
 
 /***/ }),
 
@@ -6885,7 +6885,7 @@ module.exports = require("util");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("zlib");;
+module.exports = require("zlib");
 
 /***/ })
 
@@ -6924,7 +6924,9 @@ module.exports = require("zlib");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {


### PR DESCRIPTION
Add verification step for: #62 

We can setup an automatic generation on pushing to the default branch, but for this we need a Personnal Access Token to be created to allow to push on the repo directly from CI. To be honest i prefer adding a verification step to ensure collaborators to run `npm run build`  even if there is a `husky` hook



#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
