### PR TITLE
fix: default value for target on action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action automatically approves and merges dependabot PRs.
 
 ### `exclude`
 
-_Optional_ An comma separated value of packages that you don't want to auto-merge and would like to manually review to decide whether to upgrade or not.
+_Optional_ A comma separated value of packages that you don't want to auto-merge and would like to manually review to decide whether to upgrade or not.
 
 ### `approve-only`
 
@@ -35,11 +35,13 @@ _Optional_ A custom url where the external API which is delegated the task of ap
 
 ### `target`
 
-_Optional_ A flag to only auto-merge updates based on Semantic Versioning. Default to `major` merge. Possible options are:
+_Optional_ A flag to only auto-merge updates based on Semantic Versioning. Defaults to `any`.
 
-`major, premajor, minor, preminor, patch, prepatch, prerelease or any`. Defaults to `any`.
+Possible options are:
 
-For more details on how semantic version difference calculated please see [semver](https://www.npmjs.com/package/semver) package
+`major, premajor, minor, preminor, patch, prepatch, prerelease, any`.
+
+For more details on how semantic version difference is calculated please see [semver](https://www.npmjs.com/package/semver) package.
 
 ### `pr-number`
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
   target:
     description: 'Auto-merge on major, minor, patch updates based on Semantic Versioning'
     required: false
-    default: 'major'
+    default: 'any'
   pr-number:
     description: 'A pull request number, only required if triggered from a workflow_dispatch event'
     required: false


### PR DESCRIPTION
The default value for `target` was still `major` but it has been changed to `any` here https://github.com/fastify/github-action-merge-dependabot/pull/99. 

Docs has been fixed as well, however I'm not sure about adding new tests... it would be great to have tests in place to prevent bugs like this in the future _i.e._ ensure that the documented defaults are correct.

Thanks!

_This is my first PR here so sorry in advance if anything is missing! 🙏_ 