### PR TITLE
fix: semver like titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Possible options are:
 
 For more details on how semantic version difference is calculated please see [semver](https://www.npmjs.com/package/semver) package.
 
-If you set a value other than `any`, PRs that are not semantic version compliant will not be merged.
+If you set a value other than `any`, PRs that are not semantic version compliant are skipped.
 An example of a non-semantic version is a commit hash.
 
 ### `pr-number`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Possible options are:
 
 For more details on how semantic version difference is calculated please see [semver](https://www.npmjs.com/package/semver) package.
 
+If you set a value other than `any`, PRs that are not semantic version compliant will not be merged.
+An example of a non-semantic version is a commit hash.
+
 ### `pr-number`
 
 _Optional_ A pull request number, only required if triggered from a workflow_dispatch event. Typically this would be triggered by a script running in a seperate CI provider. See [Trigger action from workflow_dispatch event](#trigger-action-from-workflow_dispatch-event)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Possible options are:
 For more details on how semantic version difference is calculated please see [semver](https://www.npmjs.com/package/semver) package.
 
 If you set a value other than `any`, PRs that are not semantic version compliant are skipped.
-An example of a non-semantic version is a commit hash.
+An example of a non-semantic version is a commit hash when using git submodules.
 
 ### `pr-number`
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6304,6 +6304,19 @@ module.exports = parse
 
 /***/ }),
 
+/***/ 9601:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const parse = __nccwpck_require__(5925)
+const valid = (version, options) => {
+  const v = parse(version, options)
+  return v ? v.version : null
+}
+module.exports = valid
+
+
+/***/ }),
+
 /***/ 2293:
 /***/ ((module) => {
 
@@ -9238,8 +9251,10 @@ function isMajorRelease(pullRequest) {
 
 const semverDiff = __nccwpck_require__(4297)
 const semverCoerce = __nccwpck_require__(3466)
+const semverValid = __nccwpck_require__(9601)
 
 const { semanticVersionOrder } = __nccwpck_require__(5013)
+const { logWarning } = __nccwpck_require__(653)
 
 const expression = /from ([^\s]+) to ([^\s]+)/
 
@@ -9251,6 +9266,12 @@ const checkTargetMatchToPR = (prTitle, target) => {
   }
 
   const [, from, to] = match
+
+  if ((!semverValid(from) && hasBadChars(from)) || (!semverValid(to) && hasBadChars(to))) {
+    logWarning(`PR title contains invalid semver versions from: ${from} to: ${to}`)
+    return false
+  }
+
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
 
   return !(
@@ -9258,6 +9279,12 @@ const checkTargetMatchToPR = (prTitle, target) => {
     semanticVersionOrder.indexOf(diff) > semanticVersionOrder.indexOf(target)
   )
 }
+
+function hasBadChars(version) {
+  // recognize submodules title likes 'Bump dotbot from `aa93350` to `acaaaac`'
+  return /`/.test(version)
+}
+
 module.exports = checkTargetMatchToPR
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6144,6 +6144,64 @@ module.exports = SemVer
 
 /***/ }),
 
+/***/ 3466:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const SemVer = __nccwpck_require__(8088)
+const parse = __nccwpck_require__(5925)
+const {re, t} = __nccwpck_require__(9523)
+
+const coerce = (version, options) => {
+  if (version instanceof SemVer) {
+    return version
+  }
+
+  if (typeof version === 'number') {
+    version = String(version)
+  }
+
+  if (typeof version !== 'string') {
+    return null
+  }
+
+  options = options || {}
+
+  let match = null
+  if (!options.rtl) {
+    match = version.match(re[t.COERCE])
+  } else {
+    // Find the right-most coercible string that does not share
+    // a terminus with a more left-ward coercible string.
+    // Eg, '1.2.3.4' wants to coerce '2.3.4', not '3.4' or '4'
+    //
+    // Walk through the string checking with a /g regexp
+    // Manually set the index so as to pick up overlapping matches.
+    // Stop when we get a match that ends at the string end, since no
+    // coercible string can be more right-ward without the same terminus.
+    let next
+    while ((next = re[t.COERCERTL].exec(version)) &&
+        (!match || match.index + match[0].length !== version.length)
+    ) {
+      if (!match ||
+            next.index + next[0].length !== match.index + match[0].length) {
+        match = next
+      }
+      re[t.COERCERTL].lastIndex = next.index + next[1].length + next[2].length
+    }
+    // leave it in a clean state
+    re[t.COERCERTL].lastIndex = -1
+  }
+
+  if (match === null)
+    return null
+
+  return parse(`${match[2]}.${match[3] || '0'}.${match[4] || '0'}`, options)
+}
+module.exports = coerce
+
+
+/***/ }),
+
 /***/ 4309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -9179,6 +9237,7 @@ function isMajorRelease(pullRequest) {
 "use strict";
 
 const semverDiff = __nccwpck_require__(4297)
+const semverCoerce = __nccwpck_require__(3466)
 
 const { semanticVersionOrder } = __nccwpck_require__(5013)
 
@@ -9190,7 +9249,9 @@ const checkTargetMatchToPR = (prTitle, target) => {
   if (!match) {
     return true
   }
-  const diff = semverDiff(match[1], match[2])
+
+  const [, from, to] = match
+  const diff = semverDiff(semverCoerce(from), semverCoerce(to))
 
   return !(
     diff &&

--- a/src/checkTargetMatchToPR.js
+++ b/src/checkTargetMatchToPR.js
@@ -1,8 +1,10 @@
 'use strict'
 const semverDiff = require('semver/functions/diff')
 const semverCoerce = require('semver/functions/coerce')
+const semverValid = require('semver/functions/valid')
 
 const { semanticVersionOrder } = require('./getTargetInput')
+const { logWarning } = require('./log')
 
 const expression = /from ([^\s]+) to ([^\s]+)/
 
@@ -15,7 +17,8 @@ const checkTargetMatchToPR = (prTitle, target) => {
 
   const [, from, to] = match
 
-  if(hasBadChars(from) || hasBadChars(to)) {
+  if ((!semverValid(from) && hasBadChars(from)) || (!semverValid(to) && hasBadChars(to))) {
+    logWarning(`PR title contains invalid semver versions from: ${from} to: ${to}`)
     return false
   }
 

--- a/src/checkTargetMatchToPR.js
+++ b/src/checkTargetMatchToPR.js
@@ -1,5 +1,6 @@
 'use strict'
 const semverDiff = require('semver/functions/diff')
+const semverCoerce = require('semver/functions/coerce')
 
 const { semanticVersionOrder } = require('./getTargetInput')
 
@@ -11,7 +12,9 @@ const checkTargetMatchToPR = (prTitle, target) => {
   if (!match) {
     return true
   }
-  const diff = semverDiff(match[1], match[2])
+
+  const [, from, to] = match
+  const diff = semverDiff(semverCoerce(from), semverCoerce(to))
 
   return !(
     diff &&

--- a/src/checkTargetMatchToPR.js
+++ b/src/checkTargetMatchToPR.js
@@ -31,6 +31,7 @@ const checkTargetMatchToPR = (prTitle, target) => {
 }
 
 function hasBadChars(version) {
+  // recognize submodules title likes 'Bump dotbot from `aa93350` to `acaaaac`'
   return /`/.test(version)
 }
 

--- a/src/checkTargetMatchToPR.js
+++ b/src/checkTargetMatchToPR.js
@@ -14,6 +14,12 @@ const checkTargetMatchToPR = (prTitle, target) => {
   }
 
   const [, from, to] = match
+
+  const isNotSemantic = isAlpha(from) 
+  
+  || isAlpha(to)
+
+
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
 
   return !(
@@ -21,4 +27,9 @@ const checkTargetMatchToPR = (prTitle, target) => {
     semanticVersionOrder.indexOf(diff) > semanticVersionOrder.indexOf(target)
   )
 }
+
+function isAlpha(version) {
+  return /[A-Z]+/i.test(version)
+}
+
 module.exports = checkTargetMatchToPR

--- a/src/checkTargetMatchToPR.js
+++ b/src/checkTargetMatchToPR.js
@@ -15,10 +15,9 @@ const checkTargetMatchToPR = (prTitle, target) => {
 
   const [, from, to] = match
 
-  const isNotSemantic = isAlpha(from) 
-  
-  || isAlpha(to)
-
+  if(hasBadChars(from) || hasBadChars(to)) {
+    return false
+  }
 
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
 
@@ -28,8 +27,8 @@ const checkTargetMatchToPR = (prTitle, target) => {
   )
 }
 
-function isAlpha(version) {
-  return /[A-Z]+/i.test(version)
+function hasBadChars(version) {
+  return /`/.test(version)
 }
 
 module.exports = checkTargetMatchToPR

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -270,9 +270,9 @@ tap.test('should check submodules semver when target is set', async t => {
     payload: {
       pull_request: {
         number: PR_NUMBER,
-        title: 'chore(deps): bump fastify/submodule from 2.5.0 to 2.6',
+        title: 'Bump dotbot from aa93350 to ac5793c',
         user: { login: BOT_NAME },
-        head: { ref: 'dependabot/github_actions/fastify/submodule-2.6' },
+        head: { ref: 'dependabot/submodules/dotbot-ac5793c' },
       }
     },
     inputs: {

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -270,7 +270,7 @@ tap.test('should check submodules semver when target is set', async t => {
     payload: {
       pull_request: {
         number: PR_NUMBER,
-        title: 'Bump dotbot from aa93350 to ac5793c',
+        title: 'Bump dotbot from `aa93350` to `ac5793c`',
         user: { login: BOT_NAME },
         head: { ref: 'dependabot/submodules/dotbot-ac5793c' },
       }
@@ -286,6 +286,6 @@ tap.test('should check submodules semver when target is set', async t => {
 
   await action()
 
-  t.ok(stubs.logStub.logInfo.calledOnceWith('pr-text'))
-  t.ok(stubs.fetchStub.calledOnce)
+  t.ok(stubs.logStub.logWarning.calledOnceWith('Target specified does not match to PR, skipping.'))
+  t.ok(stubs.fetchStub.notCalled)
 })

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -263,3 +263,29 @@ tap.test('should call external api for github-action-merge-dependabot major rele
   t.ok(stubs.logStub.logWarning.calledOnce)
   t.ok(stubs.fetchStub.calledOnce)
 })
+
+tap.test('should check submodules semver when target is set', async t => {
+  const PR_NUMBER = Math.random()
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        title: 'chore(deps): bump fastify/submodule from 2.5.0 to 2.6',
+        user: { login: BOT_NAME },
+        head: { ref: 'dependabot/github_actions/fastify/submodule-2.6' },
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      TARGET: 'minor',
+      EXCLUDE_PKGS: [],
+      API_URL: 'custom one',
+      DEFAULT_API_URL,
+    }
+  })
+
+  await action()
+
+  t.ok(stubs.logStub.logInfo.calledOnceWith('pr-text'))
+  t.ok(stubs.fetchStub.calledOnce)
+})

--- a/test/checkTargetMatchToPR.test.js
+++ b/test/checkTargetMatchToPR.test.js
@@ -18,6 +18,9 @@ const preReleaseToPathUpgradePRTitle =
   'chore(deps-dev): bump fastify from 3.18.0-alpha to 3.18.2'
 const sameVersion = 'chore(deps-dev): bump fastify from 3.18.0 to 3.18.0'
 const patchPRTitleInSubDirectory = 'chore(deps-dev): bump fastify from 3.18.0 to 3.18.1 in /packages/a'
+const semverLikeMinor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 2.3'
+const semverLikeMajor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 3'
+const semverLikeBothWay = 'chore(deps): bump nearform/optic-release-automation-action from 2 to 3'
 
 tap.test('checkTargetMatchToPR', async t => {
   t.test('should return true when target is major', async t => {
@@ -138,6 +141,29 @@ tap.test('checkTargetMatchToPR', async t => {
     })
     t.test('PR is premajor and target is minor', async t => {
       t.notOk(checkTargetMatchToPR(preMajorPRTitle, targetOptions.minor))
+    })
+  })
+
+  t.test('semver-like PR titles', async t => {
+    t.test('semver to minor semver-like', async t => {
+      t.notOk(checkTargetMatchToPR(semverLikeMinor, targetOptions.prepatch))
+      t.notOk(checkTargetMatchToPR(semverLikeMinor, targetOptions.patch))
+      t.ok(checkTargetMatchToPR(semverLikeMinor, targetOptions.minor))
+      t.ok(checkTargetMatchToPR(semverLikeMinor, targetOptions.major))
+    })
+
+    t.test('semver to major semver-like', async t => {
+      t.notOk(checkTargetMatchToPR(semverLikeMajor, targetOptions.prepatch))
+      t.notOk(checkTargetMatchToPR(semverLikeMajor, targetOptions.patch))
+      t.notOk(checkTargetMatchToPR(semverLikeMajor, targetOptions.minor))
+      t.ok(checkTargetMatchToPR(semverLikeMajor, targetOptions.major))
+    })
+
+    t.test('semver-like to semver-like', async t => {
+      t.notOk(checkTargetMatchToPR(semverLikeBothWay, targetOptions.prepatch))
+      t.notOk(checkTargetMatchToPR(semverLikeBothWay, targetOptions.patch))
+      t.notOk(checkTargetMatchToPR(semverLikeBothWay, targetOptions.minor))
+      t.ok(checkTargetMatchToPR(semverLikeBothWay, targetOptions.major))
     })
   })
 })

--- a/test/checkTargetMatchToPR.test.js
+++ b/test/checkTargetMatchToPR.test.js
@@ -21,7 +21,8 @@ const patchPRTitleInSubDirectory = 'chore(deps-dev): bump fastify from 3.18.0 to
 const semverLikeMinor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 2.3'
 const semverLikeMajor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 3'
 const semverLikeBothWay = 'chore(deps): bump nearform/optic-release-automation-action from 2 to 3'
-const submodules = 'Bump dotbot from aa93350 to ac5793c'
+const submodules = 'Bump dotbot from `aa93350` to `ac5793c`'
+const submodulesAlpha = 'Bump dotbot from `aa93350` to `acaaaac`'
 
 tap.test('checkTargetMatchToPR', async t => {
   t.test('should return true when target is major', async t => {
@@ -173,5 +174,6 @@ tap.test('checkTargetMatchToPR', async t => {
     t.notOk(checkTargetMatchToPR(submodules, targetOptions.patch))
     t.notOk(checkTargetMatchToPR(submodules, targetOptions.minor))
     t.notOk(checkTargetMatchToPR(submodules, targetOptions.major))
+    t.notOk(checkTargetMatchToPR(submodulesAlpha, targetOptions.major))
   })
 })

--- a/test/checkTargetMatchToPR.test.js
+++ b/test/checkTargetMatchToPR.test.js
@@ -21,6 +21,7 @@ const patchPRTitleInSubDirectory = 'chore(deps-dev): bump fastify from 3.18.0 to
 const semverLikeMinor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 2.3'
 const semverLikeMajor = 'chore(deps): bump nearform/optic-release-automation-action from 2.2.0 to 3'
 const semverLikeBothWay = 'chore(deps): bump nearform/optic-release-automation-action from 2 to 3'
+const submodules = 'Bump dotbot from aa93350 to ac5793c'
 
 tap.test('checkTargetMatchToPR', async t => {
   t.test('should return true when target is major', async t => {
@@ -165,5 +166,12 @@ tap.test('checkTargetMatchToPR', async t => {
       t.notOk(checkTargetMatchToPR(semverLikeBothWay, targetOptions.minor))
       t.ok(checkTargetMatchToPR(semverLikeBothWay, targetOptions.major))
     })
+  })
+
+  t.test('submodules', async t => {
+    t.notOk(checkTargetMatchToPR(submodules, targetOptions.prepatch))
+    t.notOk(checkTargetMatchToPR(submodules, targetOptions.patch))
+    t.notOk(checkTargetMatchToPR(submodules, targetOptions.minor))
+    t.notOk(checkTargetMatchToPR(submodules, targetOptions.major))
   })
 })


### PR DESCRIPTION
fixes https://github.com/fastify/github-action-merge-dependabot/issues/124

It should support submodules as well (the #98 PR adds the `any` option to skip this check)
