### PR TITLE
hotfix: release link into upgrade message

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -53,7 +53,7 @@ module.exports = async function run() {
     const { name: pkgName, version } = getPackageDetails(pr)
     const upgradeMessage = `Cannot automerge github-action-merge-dependabot ${version} major release.
   Read how to upgrade it manually:
-  https://github.com/fastify/github-action-merge-dependabot/releases/tag/v${version}`
+  https://github.com/fastify/github-action-merge-dependabot/releases/tag/v3.0.0`
 
     if (EXCLUDE_PKGS.includes(pkgName)) {
       return logInfo(`${pkgName} is excluded, skipping.`)


### PR DESCRIPTION
Creating the tag `v3` and `v3.0` (ref #112 ) manually by running:

```
git tag -f 'v3'
git tag -f 'v3.0'
git push origin --tags
```

This command does not set the tag message that appeared at:

https://github.com/fastify/github-action-merge-dependabot/releases/tag/v3

This PR forces the link to the one created using the GH-UI:

https://github.com/fastify/github-action-merge-dependabot/releases/tag/v3.0.0


### Notes

Creating a GH release needs to be verified because the `v3` and `v3.0` tags will be updated time by time and it may be blocked by GH

