### PR TITLE
fix: Standardize getModuleVersionChanges return type

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6340,7 +6340,7 @@ module.exports = SemVer
 
 const SemVer = __nccwpck_require__(8088)
 const parse = __nccwpck_require__(5925)
-const {re, t} = __nccwpck_require__(9523)
+const { re, t } = __nccwpck_require__(9523)
 
 const coerce = (version, options) => {
   if (version instanceof SemVer) {
@@ -6383,8 +6383,9 @@ const coerce = (version, options) => {
     re[t.COERCERTL].lastIndex = -1
   }
 
-  if (match === null)
+  if (match === null) {
     return null
+  }
 
   return parse(`${match[2]}.${match[3] || '0'}.${match[4] || '0'}`, options)
 }
@@ -6448,7 +6449,7 @@ module.exports = eq
 /***/ 5925:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const {MAX_LENGTH} = __nccwpck_require__(2293)
+const { MAX_LENGTH } = __nccwpck_require__(2293)
 const { re, t } = __nccwpck_require__(9523)
 const SemVer = __nccwpck_require__(8088)
 
@@ -6507,7 +6508,7 @@ const SEMVER_SPEC_VERSION = '2.0.0'
 
 const MAX_LENGTH = 256
 const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
-  /* istanbul ignore next */ 9007199254740991
+/* istanbul ignore next */ 9007199254740991
 
 // Max safe segment length for coercion.
 const MAX_SAFE_COMPONENT_LENGTH = 16
@@ -6516,7 +6517,7 @@ module.exports = {
   SEMVER_SPEC_VERSION,
   MAX_LENGTH,
   MAX_SAFE_INTEGER,
-  MAX_SAFE_COMPONENT_LENGTH
+  MAX_SAFE_COMPONENT_LENGTH,
 }
 
 
@@ -6562,7 +6563,7 @@ const rcompareIdentifiers = (a, b) => compareIdentifiers(b, a)
 
 module.exports = {
   compareIdentifiers,
-  rcompareIdentifiers
+  rcompareIdentifiers,
 }
 
 
@@ -6577,9 +6578,9 @@ const opts = ['includePrerelease', 'loose', 'rtl']
 const parseOptions = options =>
   !options ? {}
   : typeof options !== 'object' ? { loose: true }
-  : opts.filter(k => options[k]).reduce((options, k) => {
-    options[k] = true
-    return options
+  : opts.filter(k => options[k]).reduce((o, k) => {
+    o[k] = true
+    return o
   }, {})
 module.exports = parseOptions
 
@@ -6601,7 +6602,7 @@ let R = 0
 
 const createToken = (name, value, isGlobal) => {
   const index = R++
-  debug(index, value)
+  debug(name, index, value)
   t[name] = index
   src[index] = value
   re[index] = new RegExp(value, isGlobal ? 'g' : undefined)
@@ -6769,8 +6770,8 @@ createToken('HYPHENRANGELOOSE', `^\\s*(${src[t.XRANGEPLAINLOOSE]})` +
 // Star ranges basically just allow anything at all.
 createToken('STAR', '(<|>)?=?\\s*\\*')
 // >=0.0.0 is like a star
-createToken('GTE0', '^\\s*>=\\s*0\.0\.0\\s*$')
-createToken('GTE0PRE', '^\\s*>=\\s*0\.0\.0-0\\s*$')
+createToken('GTE0', '^\\s*>=\\s*0\\.0\\.0\\s*$')
+createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$')
 
 
 /***/ }),
@@ -9568,7 +9569,7 @@ const getModuleVersionChanges = (prDiff) => {
   const parsedDiffFiles = parse(prDiff)
   const packageJsonChanges = parsedDiffFiles.find((file) => file.newPath === 'package.json')
   if (!packageJsonChanges) {
-    return false
+    return {}
   }
 
   const moduleChanges = {}

--- a/dist/index.js
+++ b/dist/index.js
@@ -9381,6 +9381,7 @@ ${changedExcludedPackages.join(', ')}. Skipping.`)
 function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
+
   if (!from || !to) {
     return false
   }

--- a/src/moduleVersionChanges.js
+++ b/src/moduleVersionChanges.js
@@ -45,7 +45,7 @@ const getModuleVersionChanges = (prDiff) => {
   const parsedDiffFiles = parse(prDiff)
   const packageJsonChanges = parsedDiffFiles.find((file) => file.newPath === 'package.json')
   if (!packageJsonChanges) {
-    return false
+    return {}
   }
 
   const moduleChanges = {}

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -289,7 +289,7 @@ tap.test('should check submodules semver when target is set', async () => {
   sinon.assert.notCalled(stubs.mergeStub)
 })
 
-tap.test('should work if no changes were made to package.json', async () => {
+tap.test('should merge if no changes were made to package.json', async () => {
   const PR_NUMBER = Math.random()
   const { action, stubs } = buildStubbedAction({
     payload: {

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -288,3 +288,27 @@ tap.test('should check submodules semver when target is set', async () => {
   sinon.assert.notCalled(stubs.approveStub)
   sinon.assert.notCalled(stubs.mergeStub)
 })
+
+tap.test('should work if no changes were made to package.json', async () => {
+  const PR_NUMBER = Math.random()
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      TARGET: 'main',
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
+
+  await action()
+
+  sinon.assert.called(stubs.approveStub)
+  sinon.assert.called(stubs.mergeStub)
+})

--- a/test/moduleChanges.js
+++ b/test/moduleChanges.js
@@ -147,6 +147,20 @@ index d3dfd3d..bd28161 100644
 -        "github-action-merge-dependabot": "1.2.3",
 +        "github-action-merge-dependabot": "2.1.0",
 `,
+  noPackageJsonChanges: `
+diff --git a/test/action.test.js b/test/action.test.js
+index e8c6572..751e69d 100644
+--- a/test/action.test.js
++++ b/test/action.test.js
+@@ -9,6 +9,7 @@ const core = require('@actions/core')
+ const github = require('@actions/github')
+ const toolkit = require('actions-toolkit')
+
++
+ const { diffs } = require('./moduleChanges')
+ const actionLog = require('../src/log')
+ const actionUtil = require('../src/util')
+`
 }
 
 const moduleChanges = {}


### PR DESCRIPTION
Avoid returning false (which as far as I can see was not being used in any case) and always return an object.

Closes #172 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
