### PR TITLE
Add missing tests

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,5 +1,0 @@
-ts: false
-jsx: false
-flow: false
-check-coverage: true
-coverage: true

--- a/.taprc
+++ b/.taprc
@@ -1,5 +1,5 @@
 ts: false
 jsx: false
 flow: false
-check-coverage: false
+check-coverage: true
 coverage: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -9393,7 +9393,7 @@ function parsePrTitle(pullRequest) {
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    return {}
+    throw new Error("Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
   }
 
   const [, packageName, oldVersion, newVersion] = match

--- a/dist/index.js
+++ b/dist/index.js
@@ -9381,9 +9381,6 @@ ${changedExcludedPackages.join(', ')}. Skipping.`)
 function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
-  if (!from || !to) {
-    return false
-  }
 
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
@@ -9637,13 +9634,13 @@ const getMergeMethod = () => {
 }
 
 const parseCommaSeparatedValue = (value) => {
-  return value.split(',').map(el => el.trim());
+  return value ? value.split(',').map(el => el.trim()) : [];
 }
 
 exports.getInputs = () => ({
   GITHUB_TOKEN: core.getInput('github-token', { required: true }),
   MERGE_METHOD: getMergeMethod(),
-  EXCLUDE_PKGS: parseCommaSeparatedValue(core.getInput('exclude')) || [],
+  EXCLUDE_PKGS: parseCommaSeparatedValue(core.getInput('exclude')),
   MERGE_COMMENT: core.getInput('merge-comment') || '',
   APPROVE_ONLY: /true/i.test(core.getInput('approve-only')),
   TARGET: getTargetInput(core.getInput('target')),

--- a/dist/index.js
+++ b/dist/index.js
@@ -9384,6 +9384,10 @@ function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
 
+  if (!from || !to) {
+    return false
+  }
+
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
 }
@@ -9393,7 +9397,7 @@ function parsePrTitle(pullRequest) {
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    throw new Error("Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
+    return {}
   }
 
   const [, packageName, oldVersion, newVersion] = match

--- a/src/action.js
+++ b/src/action.js
@@ -103,7 +103,7 @@ function parsePrTitle(pullRequest) {
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    return {}
+    throw new Error("Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
   }
 
   const [, packageName, oldVersion, newVersion] = match

--- a/src/action.js
+++ b/src/action.js
@@ -91,9 +91,6 @@ ${changedExcludedPackages.join(', ')}. Skipping.`)
 function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
-  if (!from || !to) {
-    return false
-  }
 
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major

--- a/src/action.js
+++ b/src/action.js
@@ -94,6 +94,10 @@ function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
 
+  if (!from || !to) {
+    return false
+  }
+
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
 }
@@ -103,7 +107,7 @@ function parsePrTitle(pullRequest) {
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    throw new Error("Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
+    return {}
   }
 
   const [, packageName, oldVersion, newVersion] = match

--- a/src/util.js
+++ b/src/util.js
@@ -25,13 +25,13 @@ const getMergeMethod = () => {
 }
 
 const parseCommaSeparatedValue = (value) => {
-  return value.split(',').map(el => el.trim());
+  return value ? value.split(',').map(el => el.trim()) : [];
 }
 
 exports.getInputs = () => ({
   GITHUB_TOKEN: core.getInput('github-token', { required: true }),
   MERGE_METHOD: getMergeMethod(),
-  EXCLUDE_PKGS: parseCommaSeparatedValue(core.getInput('exclude')) || [],
+  EXCLUDE_PKGS: parseCommaSeparatedValue(core.getInput('exclude')),
   MERGE_COMMENT: core.getInput('merge-comment') || '',
   APPROVE_ONLY: /true/i.test(core.getInput('approve-only')),
   TARGET: getTargetInput(core.getInput('target')),

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -367,3 +367,30 @@ tap.test('should not merge major bump if updating github-action-merge-dependabot
   sinon.assert.notCalled(stubs.approveStub)
   sinon.assert.notCalled(stubs.mergeStub)
 })
+
+tap.test('should throw if the PR title is not valid', async () => {
+  const PR_NUMBER = Math.random()
+
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+        title: 'Invalid PR title'
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      TARGET: 'major',
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
+
+  await action()
+  sinon.assert.calledWith(stubs.coreStub.setFailed, "Invalid PR name, expected format `bump <package> from <old-version> to <new-version>`")
+
+  sinon.assert.notCalled(stubs.approveStub)
+  sinon.assert.notCalled(stubs.mergeStub)
+})

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -389,8 +389,32 @@ tap.test('should throw if the PR title is not valid', async () => {
   stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
 
   await action()
-  sinon.assert.calledWith(stubs.coreStub.setFailed, "Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
+  sinon.assert.called(stubs.approveStub)
+  sinon.assert.called(stubs.mergeStub)
+})
 
-  sinon.assert.notCalled(stubs.approveStub)
-  sinon.assert.notCalled(stubs.mergeStub)
+tap.test('should handle a newly added package', async () => {
+  const PR_NUMBER = Math.random()
+
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+        title: 'Invalid PR title'
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      TARGET: 'any',
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.thisModuleAdded)
+
+  await action()
+
+  sinon.assert.called(stubs.approveStub)
+  sinon.assert.called(stubs.mergeStub)
 })

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -389,7 +389,7 @@ tap.test('should throw if the PR title is not valid', async () => {
   stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
 
   await action()
-  sinon.assert.calledWith(stubs.coreStub.setFailed, "Invalid PR name, expected format `bump <package> from <old-version> to <new-version>`")
+  sinon.assert.calledWith(stubs.coreStub.setFailed, "Invalid PR title, expected format `bump <package> from <old-version> to <new-version>`")
 
   sinon.assert.notCalled(stubs.approveStub)
   sinon.assert.notCalled(stubs.mergeStub)

--- a/test/github-client.test.js
+++ b/test/github-client.test.js
@@ -37,7 +37,7 @@ const TOKEN = 'GITHUB-TOKEN'
 const PR_NUMBER = Math.floor(Math.random() * 10);
 
 tap.afterEach(() => {
-  Object.values(octokitStubs).map(stub => stub.resetHistory())
+  sinon.resetHistory();
 })
 
 tap.test('githubClient', async t => {

--- a/test/github-client.test.js
+++ b/test/github-client.test.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const tap = require('tap');
+const sinon = require('sinon');
+
+const githubContext = {
+  repository: {
+    owner: {
+      login: 'owner-login.',
+    },
+    name: 'repository-name'
+  }
+}
+
+const data = 'octokit-result'
+
+const octokitStubs = {
+  get: sinon.stub().returns(Promise.resolve({ data })),
+  createReview: sinon.stub().returns(Promise.resolve({ data })),
+  merge: sinon.stub().returns(Promise.resolve({ data })),
+}
+
+const { githubClient } = tap.mock('../src/github-client', {
+  '@actions/github': {
+    context: {
+      payload: githubContext
+    },
+    getOctokit: () => ({
+      rest: {
+        pulls: octokitStubs
+      }
+    })
+  }
+})
+
+const TOKEN = 'GITHUB-TOKEN'
+const PR_NUMBER = Math.floor(Math.random() * 10);
+
+tap.afterEach(() => {
+  Object.values(octokitStubs).map(stub => stub.resetHistory())
+})
+
+tap.test('githubClient', async t => {
+  t.test('getPullRequest', async () => {
+    const result = await githubClient(TOKEN).getPullRequest(PR_NUMBER)
+    tap.equal(result, data)
+
+    sinon.assert.calledWith(octokitStubs.get, {
+      owner: githubContext.repository.owner.login,
+      repo: githubContext.repository.name,
+      pull_number: PR_NUMBER
+    })
+  })
+
+  t.test('approvePullRequest', async () => {
+    const comment = 'Test pull request comment'
+    const result = await githubClient(TOKEN).approvePullRequest(PR_NUMBER, comment)
+    tap.equal(result, data)
+
+    sinon.assert.calledWith(octokitStubs.createReview, {
+      owner: githubContext.repository.owner.login,
+      repo: githubContext.repository.name,
+      pull_number: PR_NUMBER,
+      event: 'APPROVE',
+      body: comment
+    })
+  })
+
+  t.test('mergePullRequest', async () => {
+    const method = 'squash'
+    const result = await githubClient(TOKEN).mergePullRequest(PR_NUMBER, method)
+    tap.equal(result, data)
+
+    sinon.assert.calledWith(octokitStubs.merge, {
+      owner: githubContext.repository.owner.login,
+      repo: githubContext.repository.name,
+      pull_number: PR_NUMBER,
+      merge_method: method,
+    })
+  })
+
+  t.test('getPullRequestDiff', async () => {
+    const result = await githubClient(TOKEN).getPullRequestDiff(PR_NUMBER)
+    tap.equal(result, data)
+
+    sinon.assert.calledWith(octokitStubs.get, {
+      owner: githubContext.repository.owner.login,
+      repo: githubContext.repository.name,
+      pull_number: PR_NUMBER,
+      mediaType: {
+        format: 'diff'
+      }
+    })
+  })
+})

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -14,7 +14,7 @@ const log = tap.mock('../src/log', {
 })
 
 tap.afterEach(() => {
-  Object.values(coreStubs).map(stub => stub.resetHistory())
+  sinon.resetHistory()
 })
 
 tap.test('logError should work with numbers', async () => {

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,19 +1,40 @@
 'use strict'
 
-const log = require('../src/log')
 const tap = require('tap')
 const sinon = require('sinon')
 
-const stub = sinon.stub(log, 'logError').callThrough();
+const coreStubs = {
+  debug: sinon.stub(),
+  error: sinon.stub(),
+  info: sinon.stub(),
+  warning: sinon.stub(),
+}
+const log = tap.mock('../src/log', {
+  '@actions/core': coreStubs
+})
 
-tap.afterEach(() => stub.resetHistory())
+tap.afterEach(() => {
+  Object.values(coreStubs).map(stub => stub.resetHistory())
+})
 
 tap.test('logError should work with numbers', async () => {
   log.logError(100)
-  sinon.assert.calledWith(log.logError, 100)
+  sinon.assert.calledWith(coreStubs.error, '100')
 })
 
 tap.test('logError should work with strings', async () => {
   log.logError('100')
-  sinon.assert.calledWith(log.logError, '100')
+  sinon.assert.calledWith(coreStubs.error, '100')
+})
+
+tap.test('log should call aproppriate core function', async () => {
+  const msg = 'log message'
+  log.logError(msg)
+  sinon.assert.calledWith(coreStubs.error, msg)
+  log.logWarning(msg)
+  sinon.assert.calledWith(coreStubs.warning, msg)
+  log.logInfo(msg)
+  sinon.assert.calledWith(coreStubs.info, msg)
+  log.logDebug(msg)
+  sinon.assert.calledWith(coreStubs.debug, msg)
 })

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const log = require('../src/log')
+const tap = require('tap')
+const sinon = require('sinon')
+
+const stub = sinon.stub(log, 'logError').callThrough();
+
+tap.afterEach(() => stub.resetHistory())
+
+tap.test('logError should work with numbers', async () => {
+  log.logError(100)
+  sinon.assert.calledWith(log.logError, 100)
+})
+
+tap.test('logError should work with strings', async () => {
+  log.logError('100')
+  sinon.assert.calledWith(log.logError, '100')
+})

--- a/test/moduleChanges.js
+++ b/test/moduleChanges.js
@@ -93,6 +93,14 @@ index d3dfd3d..bd28161 100644
 -        "dotbot": "aa93350",
 +        "dotbot": "ac5793c",
 `,
+  thisModuleAdded: `
+diff --git a/package.json b/package.json
+index d3dfd3d..bd28161 100644
+--- a/package.json
++++ b/package.json
+@@ -19,9 +19,9 @@
++        "github-action-merge-dependabot": "1.4.0",
+`,
   multiplePackagesMajorMinor: `
 diff --git a/package.json b/package.json
 index d3dfd3d..bd28161 100644

--- a/test/moduleChanges.js
+++ b/test/moduleChanges.js
@@ -147,6 +147,15 @@ index d3dfd3d..bd28161 100644
 -        "github-action-merge-dependabot": "1.2.3",
 +        "github-action-merge-dependabot": "2.1.0",
 `,
+  thisModuleInvalidVersion: `
+diff --git a/package.json b/package.json
+index d3dfd3d..bd28161 100644
+--- a/package.json
++++ b/package.json
+@@ -19,9 +19,9 @@
+-        "github-action-merge-dependabot": "",
++        "github-action-merge-dependabot": "",
+`,
   noPackageJsonChanges: `
 diff --git a/test/action.test.js b/test/action.test.js
 index e8c6572..751e69d 100644

--- a/test/moduleVersionChanges.test.js
+++ b/test/moduleVersionChanges.test.js
@@ -120,4 +120,8 @@ tap.test('checkModuleVersionChanges', async t => {
     t.notOk(checkModuleVersionChanges(moduleChanges.multipleFilesDiff, targetOptions.minor))
     t.ok(checkModuleVersionChanges(moduleChanges.multipleFilesDiff, targetOptions.major))
   })
+
+  t.test('should deal with invalid package version', async t => {
+    t.notOk(checkModuleVersionChanges({ 'github-action-merge-dependabot-': { insert: '', delete: '' } }, targetOptions.minor))
+  })
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,28 @@
+'use strict'
+const tap = require('tap')
+
+tap.test('MERGE_METHOD should be squash for invalid input', async t => {
+  const { getInputs } = t.mock('../src/util', {
+    '@actions/core': {
+      'getInput': () => '',
+      debug: msg => msg,
+      error: msg => msg,
+      info: msg => msg,
+      warning: msg => msg,
+    }
+  })
+  t.equal(getInputs().MERGE_METHOD, 'squash')
+})
+
+tap.test('MERGE_METHOD should be correct for valid input', async t => {
+  const { getInputs } = tap.mock('../src/util', {
+    '@actions/core': {
+      'getInput': () => 'merge',
+      debug: msg => msg,
+      error: msg => msg,
+      info: msg => msg,
+      warning: msg => msg,
+    }
+  })
+  t.equal(getInputs().MERGE_METHOD, 'merge')
+})

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,14 +1,18 @@
 'use strict'
 const tap = require('tap')
 
+const coreStubs = {
+  'getInput': () => '',
+  debug: msg => msg,
+  error: msg => msg,
+  info: msg => msg,
+  warning: msg => msg,
+}
+
 tap.test('MERGE_METHOD should be squash for invalid input', async t => {
   const { getInputs } = t.mock('../src/util', {
     '@actions/core': {
-      'getInput': () => '',
-      debug: msg => msg,
-      error: msg => msg,
-      info: msg => msg,
-      warning: msg => msg,
+      ...coreStubs
     }
   })
   t.equal(getInputs().MERGE_METHOD, 'squash')
@@ -17,11 +21,8 @@ tap.test('MERGE_METHOD should be squash for invalid input', async t => {
 tap.test('MERGE_METHOD should be correct for valid input', async t => {
   const { getInputs } = tap.mock('../src/util', {
     '@actions/core': {
+      ...coreStubs,
       'getInput': () => 'merge',
-      debug: msg => msg,
-      error: msg => msg,
-      info: msg => msg,
-      warning: msg => msg,
     }
   })
   t.equal(getInputs().MERGE_METHOD, 'merge')


### PR DESCRIPTION
Add missing tests to achieve 100% test coverage and enforce it so tests fail if coverage drop from 100%.

Some of the tests will probably never happen in a real world scenario but are required for full coverage nonetheless.

Closes #177.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
