### PR TITLE
fix: improve PR Title parsing, handle invalid inputs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9663,11 +9663,21 @@ exports.getInputs = () => ({
   PR_NUMBER: core.getInput('pr-number'),
 })
 
+/**
+ * Get a package name from a branch name.
+ * Dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+ * or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+ */
 exports.getPackageName = (branchName) => {
-  // Get package name from branch
-  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
-  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
-  return branchName.split('/').pop().split('-').slice(0, -1).join('-')
+  const nameWithVersion = branchName.split('/').pop().split('-')
+  const version = nameWithVersion.pop()
+  const packageName = nameWithVersion.join('-')
+
+  if (!packageName || !version) {
+    throw new Error('Invalid branch name, package name or version not found')
+  }
+
+  return packageName
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9384,23 +9384,23 @@ function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
 
-  if (!from || !to) {
-    return false
-  }
-
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
 }
 
 function parsePrTitle(pullRequest) {
-  const expression = /bump (\S+) from (\S+) to (\S+)/i
+  const expression = /bump \S+ from (\S+) to (\S+)/i
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    return {}
+    throw new Error('Error while parsing PR title, expected: `bump <package> from <old-version> to <new-version>`')
   }
+  const [, oldVersion, newVersion] = match
 
-  const [, packageName, oldVersion, newVersion] = match
+  // Get package name from branch
+  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+  const packageName = pullRequest.head.ref.split('/').pop().split('-').slice(0, -1).join('-')
 
   return { [packageName]: { delete: semverCoerce(oldVersion).raw, insert: semverCoerce(newVersion).raw } }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9299,7 +9299,7 @@ const toolkit = __nccwpck_require__(2183)
 const packageInfo = __nccwpck_require__(4147)
 const { githubClient } = __nccwpck_require__(3386)
 const { logInfo, logWarning, logError } = __nccwpck_require__(653)
-const { getInputs } = __nccwpck_require__(6254)
+const { getInputs, getPackageName } = __nccwpck_require__(6254)
 const { targetOptions } = __nccwpck_require__(5013)
 const {
   getModuleVersionChanges,
@@ -9397,10 +9397,7 @@ function parsePrTitle(pullRequest) {
   }
   const [, oldVersion, newVersion] = match
 
-  // Get package name from branch
-  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
-  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
-  const packageName = pullRequest.head.ref.split('/').pop().split('-').slice(0, -1).join('-')
+  const packageName = getPackageName(pullRequest.head.ref)
 
   return { [packageName]: { delete: semverCoerce(oldVersion).raw, insert: semverCoerce(newVersion).raw } }
 }
@@ -9665,6 +9662,13 @@ exports.getInputs = () => ({
   TARGET: getTargetInput(core.getInput('target')),
   PR_NUMBER: core.getInput('pr-number'),
 })
+
+exports.getPackageName = (branchName) => {
+  // Get package name from branch
+  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+  return branchName.split('/').pop().split('-').slice(0, -1).join('-')
+}
 
 
 /***/ }),

--- a/src/action.js
+++ b/src/action.js
@@ -94,23 +94,23 @@ function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
 
-  if (!from || !to) {
-    return false
-  }
-
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
 }
 
 function parsePrTitle(pullRequest) {
-  const expression = /bump (\S+) from (\S+) to (\S+)/i
+  const expression = /bump \S+ from (\S+) to (\S+)/i
   const match = expression.exec(pullRequest.title)
 
   if (!match) {
-    return {}
+    throw new Error('Error while parsing PR title, expected: `bump <package> from <old-version> to <new-version>`')
   }
+  const [, oldVersion, newVersion] = match
 
-  const [, packageName, oldVersion, newVersion] = match
+  // Get package name from branch
+  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+  const packageName = pullRequest.head.ref.split('/').pop().split('-').slice(0, -1).join('-')
 
   return { [packageName]: { delete: semverCoerce(oldVersion).raw, insert: semverCoerce(newVersion).raw } }
 }

--- a/src/action.js
+++ b/src/action.js
@@ -9,7 +9,7 @@ const toolkit = require('actions-toolkit')
 const packageInfo = require('../package.json')
 const { githubClient } = require('./github-client')
 const { logInfo, logWarning, logError } = require('./log')
-const { getInputs } = require('./util')
+const { getInputs, getPackageName } = require('./util')
 const { targetOptions } = require('./getTargetInput')
 const {
   getModuleVersionChanges,
@@ -107,10 +107,7 @@ function parsePrTitle(pullRequest) {
   }
   const [, oldVersion, newVersion] = match
 
-  // Get package name from branch
-  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
-  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
-  const packageName = pullRequest.head.ref.split('/').pop().split('-').slice(0, -1).join('-')
+  const packageName = getPackageName(pullRequest.head.ref)
 
   return { [packageName]: { delete: semverCoerce(oldVersion).raw, insert: semverCoerce(newVersion).raw } }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -38,9 +38,19 @@ exports.getInputs = () => ({
   PR_NUMBER: core.getInput('pr-number'),
 })
 
+/**
+ * Get a package name from a branch name.
+ * Dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+ * or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+ */
 exports.getPackageName = (branchName) => {
-  // Get package name from branch
-  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
-  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
-  return branchName.split('/').pop().split('-').slice(0, -1).join('-')
+  const nameWithVersion = branchName.split('/').pop().split('-')
+  const version = nameWithVersion.pop()
+  const packageName = nameWithVersion.join('-')
+
+  if (!packageName || !version) {
+    throw new Error('Invalid branch name, package name or version not found')
+  }
+
+  return packageName
 }

--- a/src/util.js
+++ b/src/util.js
@@ -37,3 +37,10 @@ exports.getInputs = () => ({
   TARGET: getTargetInput(core.getInput('target')),
   PR_NUMBER: core.getInput('pr-number'),
 })
+
+exports.getPackageName = (branchName) => {
+  // Get package name from branch
+  // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
+  // or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+  return branchName.split('/').pop().split('-').slice(0, -1).join('-')
+}

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -297,7 +297,10 @@ tap.test('should merge major bump using PR title', async () => {
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump actions/checkout from 2 to 3'
+        title: 'build(deps): bump actions/checkout from 2 to 3',
+        head: {
+          ref: 'dependabot/github_actions/actions/checkout-3'
+        }
       }
     },
     inputs: {
@@ -323,7 +326,10 @@ tap.test('should forbid major bump using PR title', async () => {
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump actions/checkout from 2 to 3'
+        title: 'build(deps): bump actions/checkout from 2 to 3',
+        head: {
+          ref: 'dependabot/github_actions/actions/cache-3'
+        }
       }
     },
     inputs: {
@@ -350,7 +356,10 @@ tap.test('should not merge major bump if updating github-action-merge-dependabot
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump github-action-merge-dependabot from 2 to 3'
+        title: 'build(deps): bump github-action-merge-dependabot from 2 to 3 zzz',
+        head: {
+          ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-3'
+        }
       }
     },
     inputs: {
@@ -376,7 +385,10 @@ tap.test('should throw if the PR title is not valid', async () => {
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'Invalid PR title'
+        title: 'Invalid PR title',
+        head: {
+          ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
+        }
       }
     },
     inputs: {
@@ -389,32 +401,8 @@ tap.test('should throw if the PR title is not valid', async () => {
   stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
 
   await action()
-  sinon.assert.called(stubs.approveStub)
-  sinon.assert.called(stubs.mergeStub)
-})
 
-tap.test('should handle a newly added package', async () => {
-  const PR_NUMBER = Math.random()
-
-  const { action, stubs } = buildStubbedAction({
-    payload: {
-      pull_request: {
-        number: PR_NUMBER,
-        user: { login: BOT_NAME },
-        title: 'Invalid PR title'
-      }
-    },
-    inputs: {
-      PR_NUMBER,
-      TARGET: 'any',
-      EXCLUDE_PKGS: ['react'],
-    }
-  })
-
-  stubs.prDiffStub.resolves(diffs.thisModuleAdded)
-
-  await action()
-
-  sinon.assert.called(stubs.approveStub)
-  sinon.assert.called(stubs.mergeStub)
+  sinon.assert.calledWith(stubs.coreStub.setFailed, ("Error while parsing PR title, expected: `bump <package> from <old-version> to <new-version>`"))
+  sinon.assert.notCalled(stubs.approveStub)
+  sinon.assert.notCalled(stubs.mergeStub)
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const tap = require('tap')
 
+
 const coreStubs = {
   'getInput': () => '',
   debug: msg => msg,
@@ -26,4 +27,12 @@ tap.test('MERGE_METHOD should be correct for valid input', async t => {
     }
   })
   t.equal(getInputs().MERGE_METHOD, 'merge')
+})
+
+tap.test('getPackageName should get package name from branch', async t => {
+  const { getPackageName } = require('../src/util')
+
+  t.equal(getPackageName("dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"), "github-action-merge-dependabot")
+  t.equal(getPackageName("dependabot/npm_and_yarn/pkg-0.0.1"), "pkg")
+  t.equal(getPackageName("pkg-0.0.1"), "pkg")
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,6 @@
 'use strict'
 const tap = require('tap')
-
+const { getPackageName } = require('../src/util')
 
 const coreStubs = {
   'getInput': () => '',
@@ -29,10 +29,14 @@ tap.test('MERGE_METHOD should be correct for valid input', async t => {
   t.equal(getInputs().MERGE_METHOD, 'merge')
 })
 
-tap.test('getPackageName should get package name from branch', async t => {
-  const { getPackageName } = require('../src/util')
-
+tap.test('getPackageName should get package name from branch with repo name', async t => {
   t.equal(getPackageName("dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"), "github-action-merge-dependabot")
+})
+
+tap.test('getPackageName should get package name from branch', async t => {
   t.equal(getPackageName("dependabot/npm_and_yarn/pkg-0.0.1"), "pkg")
-  t.equal(getPackageName("pkg-0.0.1"), "pkg")
+})
+
+tap.test('getPackageName should throw an error for invalid branch names', async t => {
+  t.throws(() => getPackageName("invalidbranchname"), new Error('Invalid branch name, package name or version not found'))
 })


### PR DESCRIPTION
Improve handling of invalid PR titles.
Parse package name from branch name to avoid issues.

Closes #185

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
