### PR TITLE
Handle commit hash versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6311,7 +6311,7 @@ class SemVer {
         if (identifier) {
           // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
           // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
-          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+          if (this.prerelease[0] === identifier) {
             if (isNaN(this.prerelease[1])) {
               this.prerelease = [identifier, 0]
             }
@@ -6482,19 +6482,6 @@ const parse = (version, options) => {
 }
 
 module.exports = parse
-
-
-/***/ }),
-
-/***/ 9601:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-const parse = __nccwpck_require__(5925)
-const valid = (version, options) => {
-  const v = parse(version, options)
-  return v ? v.version : null
-}
-module.exports = valid
 
 
 /***/ }),
@@ -9299,7 +9286,7 @@ const toolkit = __nccwpck_require__(2183)
 const packageInfo = __nccwpck_require__(4147)
 const { githubClient } = __nccwpck_require__(3386)
 const { logInfo, logWarning, logError } = __nccwpck_require__(653)
-const { getInputs, getPackageName } = __nccwpck_require__(6254)
+const { isCommitHash, getInputs, getPackageName } = __nccwpck_require__(6254)
 const { targetOptions } = __nccwpck_require__(5013)
 const {
   getModuleVersionChanges,
@@ -9384,6 +9371,10 @@ function isAMajorReleaseBump(change) {
   const from = change.delete
   const to = change.insert
 
+  if (isCommitHash(from) && isCommitHash(to))  {
+    return false
+  }
+
   const diff = semverDiff(semverCoerce(from), semverCoerce(to))
   return diff === targetOptions.major
 }
@@ -9395,11 +9386,27 @@ function parsePrTitle(pullRequest) {
   if (!match) {
     throw new Error('Error while parsing PR title, expected: `bump <package> from <old-version> to <new-version>`')
   }
-  const [, oldVersion, newVersion] = match
+
+  const [, oldVersion, newVersion] = match.map(t => t.replace(/`/g, ''))
 
   const packageName = getPackageName(pullRequest.head.ref)
 
-  return { [packageName]: { delete: semverCoerce(oldVersion).raw, insert: semverCoerce(newVersion).raw } }
+  if (semverCoerce(oldVersion) && semverCoerce(newVersion)) {
+    return {
+      [packageName]: {
+        delete: semverCoerce(oldVersion).raw,
+        insert: semverCoerce(newVersion).raw
+      }
+    }
+  } else  {
+    return {
+      [packageName]: {
+        delete: oldVersion,
+        insert: newVersion
+      }
+    }
+  }
+
 }
 
 
@@ -9539,18 +9546,12 @@ exports.logWarning = log(warning)
 
 const semverDiff = __nccwpck_require__(4297)
 const semverCoerce = __nccwpck_require__(3466)
-const semverValid = __nccwpck_require__(9601)
 const { parse } = __nccwpck_require__(153)
+const { isCommitHash } = __nccwpck_require__(6254)
 
 const { semanticVersionOrder } = __nccwpck_require__(5013)
-const { logWarning } = __nccwpck_require__(653)
 
 const expression = /"([^\s]+)":\s*"([^\s]+)"/
-
-function hasBadChars(version) {
-  // recognize submodules title likes 'Bump dotbot from `aa93350` to `acaaaac`'
-  return /^[^^~*-0-9+x]/.test(version)
-}
 
 const checkModuleVersionChanges = (moduleChanges, target) => {
   for (const module in moduleChanges) {
@@ -9561,9 +9562,12 @@ const checkModuleVersionChanges = (moduleChanges, target) => {
       return false
     }
 
-    if ((!semverValid(from) && hasBadChars(from)) || (!semverValid(to) && hasBadChars(to))) {
-      logWarning(`Module "${module}" contains invalid semver versions from: ${from} to: ${to}`)
-      return false
+    if (isCommitHash(from) && isCommitHash(to)) {
+      return true
+    }
+
+    if (!semverCoerce(from) || !semverCoerce(to)) {
+      throw new Error(`Module "${module}" contains invalid semver versions from: ${from} to: ${to}`)
     }
 
     const diff = semverDiff(semverCoerce(from), semverCoerce(to))
@@ -9678,6 +9682,10 @@ exports.getPackageName = (branchName) => {
   }
 
   return packageName
+}
+
+exports.isCommitHash = function(version) {
+  return /^[\w]{7}$/.test(version)
 }
 
 
@@ -9815,7 +9823,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"github-action-merge-dependabot","version":"3.1.4","description":"A GitHub action to automatically merge and approve Dependabot pull requests","main":"src/index.js","scripts":{"build":"ncc build src/index.js","lint":"eslint .","test":"tap","prepare":"husky install"},"author":{"name":"Salman Mitha","email":"SalmanMitha@gmail.com"},"contributors":["Simone Busoli <simone.busoli@nearform.com>"],"license":"MIT","repository":{"type":"git","url":"git+https://github.com/fastify/github-action-merge-dependabot.git"},"bugs":{"url":"https://github.com/fastify/github-action-merge-dependabot/issues"},"homepage":"https://github.com/fastify/github-action-merge-dependabot#readme","dependencies":{"@actions/core":"^1.6.0","@actions/github":"^5.0.1","actions-toolkit":"github:nearform/actions-toolkit","gitdiff-parser":"^0.2.2","semver":"^7.3.7"},"devDependencies":{"@vercel/ncc":"^0.33.4","eslint":"^8.14.0","husky":"^7.0.4","prettier":"^2.6.2","proxyquire":"^2.1.3","sinon":"^13.0.2","tap":"^16.1.0"}}');
+module.exports = JSON.parse('{"name":"github-action-merge-dependabot","version":"3.1.4","description":"A GitHub action to automatically merge and approve Dependabot pull requests","main":"src/index.js","scripts":{"build":"ncc build src/index.js","lint":"eslint .","test":"tap test/**.test.js","prepare":"husky install"},"author":{"name":"Salman Mitha","email":"SalmanMitha@gmail.com"},"contributors":["Simone Busoli <simone.busoli@nearform.com>"],"license":"MIT","repository":{"type":"git","url":"git+https://github.com/fastify/github-action-merge-dependabot.git"},"bugs":{"url":"https://github.com/fastify/github-action-merge-dependabot/issues"},"homepage":"https://github.com/fastify/github-action-merge-dependabot#readme","dependencies":{"@actions/core":"^1.7.0","@actions/github":"^5.0.1","actions-toolkit":"github:nearform/actions-toolkit","gitdiff-parser":"^0.2.2","semver":"^7.3.7"},"devDependencies":{"@vercel/ncc":"^0.33.4","eslint":"^8.14.0","husky":"^7.0.4","prettier":"^2.6.2","proxyquire":"^2.1.3","sinon":"^13.0.2","tap":"^16.1.0"}}');
 
 /***/ })
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "ncc build src/index.js",
     "lint": "eslint .",
-    "test": "tap",
+    "test": "tap test/**.test.js",
     "prepare": "husky install"
   },
   "author": {

--- a/src/moduleVersionChanges.js
+++ b/src/moduleVersionChanges.js
@@ -3,7 +3,7 @@
 const semverDiff = require('semver/functions/diff')
 const semverCoerce = require('semver/functions/coerce')
 const { parse } = require('gitdiff-parser')
-const { isCommitHash } = require('./util')
+const { isCommitHash, isValidSemver } = require('./util')
 
 const { semanticVersionOrder } = require('./getTargetInput')
 
@@ -22,7 +22,7 @@ const checkModuleVersionChanges = (moduleChanges, target) => {
       return true
     }
 
-    if (!semverCoerce(from) || !semverCoerce(to)) {
+    if (!isValidSemver(from) || !isValidSemver(to)) {
       throw new Error(`Module "${module}" contains invalid semver versions from: ${from} to: ${to}`)
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const semverValid = require('semver/functions/valid')
+const semverCoerce = require('semver/functions/coerce')
 const core = require('@actions/core')
 
 const { getTargetInput } = require('./getTargetInput')
@@ -42,6 +44,8 @@ exports.getInputs = () => ({
  * Get a package name from a branch name.
  * Dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
  * or "dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0"
+ * @param {String} branchName
+ * @returns Package name extracted from branch
  */
 exports.getPackageName = (branchName) => {
   const nameWithVersion = branchName.split('/').pop().split('-')
@@ -55,6 +59,30 @@ exports.getPackageName = (branchName) => {
   return packageName
 }
 
+/**
+ * Checks if the string is a SHA1 commit hash.
+ * Usually github commit hashes are 7 chars long, but in case this change someday
+ * it's checking for the maximum length of a SHA1 hash (40 hexadecimal chars)
+ * @param {String} version
+ * @returns Boolean indicating whether version
+ */
 exports.isCommitHash = function(version) {
-  return /^[\w]{7}$/.test(version)
+  return /^[a-f0-9]{5,40}$/.test(version)
+}
+
+/**
+ * Checks if a version is a valid semver version.
+ * Uses loose: true and replace `v`, `~`, `^` charactes to make function a bit
+ * less restrictive regarding the accepted inputs
+ * @param {String} version
+ * @returns Boolean indicating whether version is valid
+ */
+exports.isValidSemver = function (version) {
+  const isNumber = !isNaN(+version)
+
+  if (isNumber) {
+    return semverValid(semverCoerce(version))
+  }
+
+  return semverValid(version.replace(/[\^~v]/g, ''), { loose: true })
 }

--- a/src/util.js
+++ b/src/util.js
@@ -54,3 +54,7 @@ exports.getPackageName = (branchName) => {
 
   return packageName
 }
+
+exports.isCommitHash = function(version) {
+  return /^[\w]{7}$/.test(version)
+}

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -288,7 +288,36 @@ tap.test('should check PR diff with commit hash version when target is set', asy
   sinon.assert.called(stubs.mergeStub)
 })
 
-tap.test('should merge major bump using PR title', async () => {
+tap.test('should merge major bump using PR title with proper semver versions', async () => {
+  const PR_NUMBER = Math.random()
+
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+        title: 'build(deps): bump actions/checkout from 2.0.0 to 3.0.0',
+        head: {
+          ref: 'dependabot/github_actions/actions/checkout-3'
+        }
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      TARGET: 'major',
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
+
+  await action()
+
+  sinon.assert.called(stubs.approveStub)
+  sinon.assert.called(stubs.mergeStub)
+})
+
+tap.test('should merge major bump using PR title with coerceable semver versions', async () => {
   const PR_NUMBER = Math.random()
 
   const { action, stubs } = buildStubbedAction({
@@ -317,7 +346,7 @@ tap.test('should merge major bump using PR title', async () => {
   sinon.assert.called(stubs.mergeStub)
 })
 
-tap.test('should forbid major bump using PR title', async () => {
+tap.test('should forbid major bump using PR title when target is minor', async () => {
   const PR_NUMBER = Math.random()
 
   const { action, stubs } = buildStubbedAction({
@@ -445,7 +474,7 @@ tap.test('should merge with commit hashes on PR title without a target', async (
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump actions-toolkit from `044e827` to `cc221b3`',
+        title: 'build(deps): bump actions-toolkit from `cc221b3` to `044e827`',
         head: {
           ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
         }
@@ -474,7 +503,7 @@ tap.test('should not merge with unrecognized versions on PR title with a target'
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump actions-toolkit from `000044e827` to `0000cc221b3`',
+        title: 'build(deps): bump actions-toolkit from `0004x4e827` to `00ccx221b3`',
         head: {
           ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
         }
@@ -504,7 +533,7 @@ tap.test('should not merge with unrecognized versions on PR title without a targ
       pull_request: {
         number: PR_NUMBER,
         user: { login: BOT_NAME },
-        title: 'build(deps): bump actions-toolkit from `000044e827` to `0000cc221b3`',
+        title: 'build(deps): bump actions-toolkit from `00-044e827` to `0-00cc221b3`',
         head: {
           ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
         }

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -406,7 +406,7 @@ tap.test('should throw if the PR title is not valid', async () => {
   sinon.assert.notCalled(stubs.mergeStub)
 })
 
-tap.test('should merge with commit hashes on PR title', async () => {
+tap.test('should merge with commit hashes on PR title with a target', async () => {
   const PR_NUMBER = Math.random()
 
   const { action, stubs } = buildStubbedAction({
@@ -436,7 +436,37 @@ tap.test('should merge with commit hashes on PR title', async () => {
   sinon.assert.called(stubs.mergeStub)
 })
 
-tap.test('should not merge with unrecognized versions on PR title', async () => {
+
+tap.test('should merge with commit hashes on PR title without a target', async () => {
+  const PR_NUMBER = Math.random()
+
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+        title: 'build(deps): bump actions-toolkit from `044e827` to `cc221b3`',
+        head: {
+          ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
+        }
+      }
+    },
+    inputs: {
+      PR_NUMBER,
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
+
+  await action()
+
+  sinon.assert.notCalled(stubs.coreStub.setFailed)
+  sinon.assert.called(stubs.approveStub)
+  sinon.assert.called(stubs.mergeStub)
+})
+
+tap.test('should not merge with unrecognized versions on PR title with a target', async () => {
   const PR_NUMBER = Math.random()
 
   const { action, stubs } = buildStubbedAction({
@@ -453,6 +483,35 @@ tap.test('should not merge with unrecognized versions on PR title', async () => 
     inputs: {
       PR_NUMBER,
       TARGET: 'major',
+      EXCLUDE_PKGS: ['react'],
+    }
+  })
+
+  stubs.prDiffStub.resolves(diffs.noPackageJsonChanges)
+
+  await action()
+
+  sinon.assert.called(stubs.coreStub.setFailed)
+  sinon.assert.notCalled(stubs.approveStub)
+  sinon.assert.notCalled(stubs.mergeStub)
+})
+
+tap.test('should not merge with unrecognized versions on PR title without a target', async () => {
+  const PR_NUMBER = Math.random()
+
+  const { action, stubs } = buildStubbedAction({
+    payload: {
+      pull_request: {
+        number: PR_NUMBER,
+        user: { login: BOT_NAME },
+        title: 'build(deps): bump actions-toolkit from `000044e827` to `0000cc221b3`',
+        head: {
+          ref: 'dependabot/github_actions/fastify/github-action-merge-dependabot-2.6.0'
+        }
+      }
+    },
+    inputs: {
+      PR_NUMBER,
       EXCLUDE_PKGS: ['react'],
     }
   })

--- a/test/moduleChanges.js
+++ b/test/moduleChanges.js
@@ -84,7 +84,7 @@ index d3dfd3d..bd28161 100644
 -        "react": "^17.0.2",
 +        "react": "^17.0.2",
 `,
-  submodules: `
+  commitHash: `
 diff --git a/package.json b/package.json
 index d3dfd3d..bd28161 100644
 --- a/package.json

--- a/test/moduleVersionChanges.test.js
+++ b/test/moduleVersionChanges.test.js
@@ -97,11 +97,11 @@ tap.test('checkModuleVersionChanges', async t => {
     })
   })
 
-  t.test('submodules', async t => {
-    t.notOk(checkModuleVersionChanges(moduleChanges.submodules, targetOptions.prepatch))
-    t.notOk(checkModuleVersionChanges(moduleChanges.submodules, targetOptions.patch))
-    t.notOk(checkModuleVersionChanges(moduleChanges.submodules, targetOptions.minor))
-    t.notOk(checkModuleVersionChanges(moduleChanges.submodules, targetOptions.major))
+  t.test('commit hash', async t => {
+    t.ok(checkModuleVersionChanges(moduleChanges.commitHash, targetOptions.prepatch))
+    t.ok(checkModuleVersionChanges(moduleChanges.commitHash, targetOptions.patch))
+    t.ok(checkModuleVersionChanges(moduleChanges.commitHash, targetOptions.minor))
+    t.ok(checkModuleVersionChanges(moduleChanges.commitHash, targetOptions.major))
   })
 
   t.test('should return false when', async t => {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,6 @@
 'use strict'
 const tap = require('tap')
-const { isCommitHash, getPackageName } = require('../src/util')
+const { isValidSemver, isCommitHash, getPackageName } = require('../src/util')
 
 const coreStubs = {
   'getInput': () => '',
@@ -44,6 +44,14 @@ tap.test('getPackageName should throw an error for invalid branch names', async 
 tap.test('isCommitHash should detect 7 digit commit hashes properly', async t => {
   t.ok(isCommitHash('044e827'))
   t.ok(isCommitHash('cc221b3'))
-  t.notOk(isCommitHash('0000cc221b3'))
+  t.notOk(isCommitHash('0000cc221b0000cc221b0000cc221b0000cc221b2')) // Hash larger than 40 chars, the SHA1 hash length
+  t.notOk(isCommitHash('ccx21b3')) // Hash larger than 40 chars, the SHA1 hash length
   t.notOk(isCommitHash('cc-21b3'))
+})
+
+tap.test('isSemverValid should detect semver versions appropriately', async t => {
+  t.ok(isValidSemver('2'))
+  t.ok(isValidSemver('2.0.0'))
+  t.notOk(isValidSemver('2.0.0.0'))
+  t.notOk(isValidSemver('044e827'))
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -41,11 +41,12 @@ tap.test('getPackageName should throw an error for invalid branch names', async 
   t.throws(() => getPackageName("invalidbranchname"), new Error('Invalid branch name, package name or version not found'))
 })
 
-tap.test('isCommitHash should detect 7 digit commit hashes properly', async t => {
+tap.test('isCommitHash should detect variable length SHA1 hashes properly', async t => {
   t.ok(isCommitHash('044e827'))
   t.ok(isCommitHash('cc221b3'))
+  t.ok(isCommitHash('0000cc221b0000cc221b0000cc221b0000cc221b'))
   t.notOk(isCommitHash('0000cc221b0000cc221b0000cc221b0000cc221b2')) // Hash larger than 40 chars, the SHA1 hash length
-  t.notOk(isCommitHash('ccx21b3')) // Hash larger than 40 chars, the SHA1 hash length
+  t.notOk(isCommitHash('ccx21b3'))
   t.notOk(isCommitHash('cc-21b3'))
 })
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,6 @@
 'use strict'
 const tap = require('tap')
-const { getPackageName } = require('../src/util')
+const { isCommitHash, getPackageName } = require('../src/util')
 
 const coreStubs = {
   'getInput': () => '',
@@ -39,4 +39,11 @@ tap.test('getPackageName should get package name from branch', async t => {
 
 tap.test('getPackageName should throw an error for invalid branch names', async t => {
   t.throws(() => getPackageName("invalidbranchname"), new Error('Invalid branch name, package name or version not found'))
+})
+
+tap.test('isCommitHash should detect 7 digit commit hashes properly', async t => {
+  t.ok(isCommitHash('044e827'))
+  t.ok(isCommitHash('cc221b3'))
+  t.notOk(isCommitHash('0000cc221b3'))
+  t.notOk(isCommitHash('cc-21b3'))
 })


### PR DESCRIPTION
This change re-add support for commit hash versions on both PR diff and title (which I believe were removed after the PR diff changes). They will be merged independently of the target option since the hash doesn't have that information.

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Closes #199 
Closes https://github.com/nearform/github-action-notify-release/pull/189