### PR TITLE
feat: add support to dependabot's compatibility score

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ An example of a non-semantic version is a commit hash when using git submodules.
 
 _Optional_ A pull request number, only required if triggered from a workflow_dispatch event. Typically this would be triggered by a script running in a seperate CI provider. See [Trigger action from workflow_dispatch event](#trigger-action-from-workflow_dispatch-event)
 
+### `compatibility-score`
+
+_Optional_ A minimum [Compatibility score](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates#about-compatibility-scores) needed for the PR to be merged.
+
 ## Usage
 
 Configure this action in your workflows providing the inputs described above.

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   pr-number:
     description: 'A pull request number, only required if triggered from a workflow_dispatch event'
     required: false
+  compatibility-score:
+    description: 'The minimum compatibility score required for the PR to be merged (0-100)'
+    required: false
 
 runs:
   using: 'composite'
@@ -36,6 +39,8 @@ runs:
       id: dependabot-metadata
       uses: dependabot/fetch-metadata@v1
       if: ${{ github.actor == 'dependabot[bot]' }}
+      with:
+        compat-lookup: true
     - name: Merge/approve PR
       uses: actions/github-script@v6
       if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
@@ -51,6 +56,7 @@ runs:
               updateType:  '${{ steps.dependabot-metadata.outputs.update-type }}',
               dependencyType:'${{ steps.dependabot-metadata.outputs.dependency-type }}',
               dependencyNames: '${{ steps.dependabot-metadata.outputs.dependency-names }}',
+              compatibilityScore: '${{ steps.dependabot-metadata.outputs.compatibility-score }}',
             }
           })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -140,6 +140,7 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
+const uuid_1 = __nccwpck_require__(974);
 const oidc_utils_1 = __nccwpck_require__(41);
 /**
  * The code to exit an action
@@ -169,9 +170,20 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
+        if (name.includes(delimiter)) {
+            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedVal.includes(delimiter)) {
+            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+        }
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
     }
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -189,7 +201,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueFileCommand('PATH', inputPath);
+        file_command_1.issueCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -229,10 +241,7 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    if (options && options.trimWhitespace === false) {
-        return inputs;
-    }
-    return inputs.map(input => input.trim());
+    return inputs;
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -265,12 +274,8 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
-    const filePath = process.env['GITHUB_OUTPUT'] || '';
-    if (filePath) {
-        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
-    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
+    command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
 /**
@@ -399,11 +404,7 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    const filePath = process.env['GITHUB_STATE'] || '';
-    if (filePath) {
-        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
-    }
-    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
+    command_1.issueCommand('save-state', { name }, value);
 }
 exports.saveState = saveState;
 /**
@@ -469,14 +470,13 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
+exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(147));
 const os = __importStar(__nccwpck_require__(37));
-const uuid_1 = __nccwpck_require__(974);
 const utils_1 = __nccwpck_require__(278);
-function issueFileCommand(command, message) {
+function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -488,22 +488,7 @@ function issueFileCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueFileCommand = issueFileCommand;
-function prepareKeyValueMessage(key, value) {
-    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-    const convertedValue = utils_1.toCommandValue(value);
-    // These should realistically never happen, but just in case someone finds a
-    // way to exploit uuid generation let's not allow keys or values that contain
-    // the delimiter.
-    if (key.includes(delimiter)) {
-        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-    }
-    if (convertedValue.includes(delimiter)) {
-        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-    }
-    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
-}
-exports.prepareKeyValueMessage = prepareKeyValueMessage;
+exports.issueCommand = issueCommand;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),
@@ -2760,6 +2745,7 @@ module.exports = async function run({
     APPROVE_ONLY,
     TARGET,
     PR_NUMBER,
+    COMPATIBILITY_SCORE,
   } = getInputs(inputs)
 
   try {
@@ -2792,6 +2778,20 @@ module.exports = async function run({
       return logWarning(
         'PR contains invalid dependabot commit signatures, skipping.'
       )
+    }
+
+    const targetScore = +COMPATIBILITY_SCORE
+    const compatScore = +dependabotMetadata.compatibilityScore
+
+    if (
+      !isNaN(targetScore) &&
+      !isNaN(compatScore) &&
+      compatScore < targetScore
+    ) {
+      core.setFailed(
+        `Compatibility score is lower than allowed. Expected at least ${targetScore} but received ${compatScore}`
+      )
+      return
     }
 
     if (
@@ -3056,6 +3056,7 @@ exports.getInputs = inputs => {
     APPROVE_ONLY: /true/i.test(inputs['approve-only']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    COMPATIBILITY_SCORE: inputs['compatibility-score'],
   }
 }
 

--- a/src/action.js
+++ b/src/action.js
@@ -30,6 +30,7 @@ module.exports = async function run({
     APPROVE_ONLY,
     TARGET,
     PR_NUMBER,
+    COMPATIBILITY_SCORE,
   } = getInputs(inputs)
 
   try {
@@ -62,6 +63,20 @@ module.exports = async function run({
       return logWarning(
         'PR contains invalid dependabot commit signatures, skipping.'
       )
+    }
+
+    const targetScore = +COMPATIBILITY_SCORE
+    const compatScore = +dependabotMetadata.compatibilityScore
+
+    if (
+      !isNaN(targetScore) &&
+      !isNaN(compatScore) &&
+      compatScore < targetScore
+    ) {
+      core.setFailed(
+        `Compatibility score is lower than allowed. Expected at least ${targetScore} but received ${compatScore}`
+      )
+      return
     }
 
     if (

--- a/src/util.js
+++ b/src/util.js
@@ -45,5 +45,6 @@ exports.getInputs = inputs => {
     APPROVE_ONLY: /true/i.test(inputs['approve-only']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    COMPATIBILITY_SCORE: inputs['compatibility-score'],
   }
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -91,6 +91,16 @@ tap.test('getInputs', async t => {
       t.test('PR_NUMBER', async t => {
         t.equal(getInputs({ 'pr-number': '10' }).PR_NUMBER, '10')
       })
+      t.test('COMPATIBILITY_SCORE', async t => {
+        t.equal(
+          getInputs({ 'compatibility-score': '10' }).COMPATIBILITY_SCORE,
+          '10'
+        )
+        t.equal(
+          getInputs({ 'compatibility-score': '10' }).COMPATIBILITY_SCORE,
+          '10'
+        )
+      })
     }
   )
 })


### PR DESCRIPTION
This PR adds support for using dependabot's compatibility score (retrieved from dependabot's fetch-metadata action) to decide whether to merge a PR or not.

Closes #286

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
