### PR TITLE
fix: dependabot/fetch-metadata throw on push event

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Fetch metadata
       id: dependabot-metadata
       uses: dependabot/fetch-metadata@v1
-      if: ${{ github.actor == 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
     - name: Merge/approve PR
       uses: actions/github-script@v6
       if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}


### PR DESCRIPTION
Suppress #310
Fixes #311 

In the issue, it believes the problem is cause by running the action in `pull` event and the filter to restrict on `main` branch will solve the problem.
However, the main cause is `dependabot/fetch-metadata` never expected to run on [`push` event](https://github.com/dependabot/fetch-metadata/blob/ec8c26ab81e2df3417db090db57bc7aefd7f114b/src/dependabot/verified_commits.ts#L12) and the branch other than [`dependabot/*`](https://github.com/dependabot/fetch-metadata/blob/ec8c26ab81e2df3417db090db57bc7aefd7f114b/src/dependabot/update_metadata.ts#L35) . So, it will [throws on certain edge case](https://github.com/dependabot/fetch-metadata/blob/main/src/main.ts#L33-L46).

This PR restrict `dependabot/fetch-metadata` only runs on the event that should run.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
