### PR TITLE
Fix GHES support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _Optional_ A pull request number, only required if triggered from a workflow_dis
 
 ### `skip-commit-verification`
 
-_Optional_ If true, then the [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata) action will not expect the commits to have a verification signature. It is required to set this to true in GitHub Enterprise Server.
+_Optional_ If true, then the action will not expect the commits to have a verification signature. It is required to set this to true in GitHub Enterprise Server.
 
 ## Usage
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3111,7 +3111,7 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
-    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
+    SKIP_COMMIT_VERIFICATION: /true/i.test(inputs['skip-commit-verification']),
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2782,6 +2782,7 @@ module.exports = async function run({
     USE_GITHUB_AUTO_MERGE,
     TARGET,
     PR_NUMBER,
+    SKIP_COMMIT_VERIFICATION,
   } = getInputs(inputs)
 
   try {
@@ -2808,12 +2809,14 @@ module.exports = async function run({
       return logWarning('PR contains non dependabot commits, skipping.')
     }
 
-    try {
-      await verifyCommits(commits)
-    } catch {
-      return logWarning(
-        'PR contains invalid dependabot commit signatures, skipping.'
-      )
+    if (!SKIP_COMMIT_VERIFICATION) {
+      try {
+        await verifyCommits(commits)
+      } catch {
+        return logWarning(
+          'PR contains invalid dependabot commit signatures, skipping.'
+        )
+      }
     }
 
     if (
@@ -3108,6 +3111,7 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2811,7 +2811,7 @@ module.exports = async function run({
 
     if (!SKIP_COMMIT_VERIFICATION) {
       try {
-        await verifyCommits(commits)
+        verifyCommits(commits)
       } catch {
         return logWarning(
           'PR contains invalid dependabot commit signatures, skipping.'

--- a/src/action.js
+++ b/src/action.js
@@ -60,7 +60,7 @@ module.exports = async function run({
 
     if (!SKIP_COMMIT_VERIFICATION) {
       try {
-        await verifyCommits(commits)
+        verifyCommits(commits)
       } catch {
         return logWarning(
           'PR contains invalid dependabot commit signatures, skipping.'

--- a/src/action.js
+++ b/src/action.js
@@ -31,6 +31,7 @@ module.exports = async function run({
     USE_GITHUB_AUTO_MERGE,
     TARGET,
     PR_NUMBER,
+    SKIP_COMMIT_VERIFICATION,
   } = getInputs(inputs)
 
   try {
@@ -57,12 +58,14 @@ module.exports = async function run({
       return logWarning('PR contains non dependabot commits, skipping.')
     }
 
-    try {
-      await verifyCommits(commits)
-    } catch {
-      return logWarning(
-        'PR contains invalid dependabot commit signatures, skipping.'
-      )
+    if (!SKIP_COMMIT_VERIFICATION) {
+      try {
+        await verifyCommits(commits)
+      } catch {
+        return logWarning(
+          'PR contains invalid dependabot commit signatures, skipping.'
+        )
+      }
     }
 
     if (

--- a/src/util.js
+++ b/src/util.js
@@ -46,5 +46,6 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -46,6 +46,6 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
-    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
+    SKIP_COMMIT_VERIFICATION: /true/i.test(inputs['skip-commit-verification']),
   }
 }

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -79,9 +79,7 @@ function buildStubbedAction({ payload, inputs, dependabotMetadata }) {
     getPullRequestCommits: prCommitsStub.resolves([]),
   })
 
-  const verifyCommitsStub = sinon
-    .stub(verifyCommits, 'verifyCommits')
-    .returns(Promise.resolve())
+  const verifyCommitsStub = sinon.stub(verifyCommits, 'verifyCommits')
 
   const action = proxyquire('../src/action', {
     '@actions/core': coreStub,
@@ -231,7 +229,7 @@ tap.test(
       },
     ])
 
-    stubs.verifyCommitsStub.rejects()
+    stubs.verifyCommitsStub.throws()
 
     await action()
 
@@ -269,8 +267,6 @@ tap.test(
         },
       },
     ])
-
-    stubs.verifyCommitsStub.rejects()
 
     await action()
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -32,6 +32,15 @@ tap.test('parseCommaOrSemicolonSeparatedValue', async t => {
   })
 })
 
+const BOOLEAN_INPUTS = [
+  { input: 'approve-only', key: 'APPROVE_ONLY' },
+  { input: 'use-github-auto-merge', key: 'USE_GITHUB_AUTO_MERGE' },
+  {
+    input: 'skip-commit-verification',
+    key: 'SKIP_COMMIT_VERIFICATION',
+  },
+]
+
 tap.test('getInputs', async t => {
   t.test('should fail if no inputs object is provided', async t => {
     t.throws(() => getInputs())
@@ -60,14 +69,16 @@ tap.test('getInputs', async t => {
           'test-merge-comment'
         )
       })
-      t.test('APPROVE_ONLY', async t => {
-        t.equal(getInputs({}).APPROVE_ONLY, false)
-        t.equal(getInputs({ 'approve-only': 'false' }).APPROVE_ONLY, false)
-        t.equal(getInputs({ 'approve-only': 'False' }).APPROVE_ONLY, false)
-        t.equal(getInputs({ 'approve-only': 'FALSE' }).APPROVE_ONLY, false)
-        t.equal(getInputs({ 'approve-only': 'true' }).APPROVE_ONLY, true)
-        t.equal(getInputs({ 'approve-only': 'True' }).APPROVE_ONLY, true)
-        t.equal(getInputs({ 'approve-only': 'TRUE' }).APPROVE_ONLY, true)
+      t.test('BOOLEAN INPUTS', async t => {
+        BOOLEAN_INPUTS.forEach(({ input, key }) => {
+          t.equal(getInputs({})[key], false)
+          t.equal(getInputs({ [input]: 'false' })[key], false)
+          t.equal(getInputs({ [input]: 'False' })[key], false)
+          t.equal(getInputs({ [input]: 'FALSE' })[key], false)
+          t.equal(getInputs({ [input]: 'true' })[key], true)
+          t.equal(getInputs({ [input]: 'True' })[key], true)
+          t.equal(getInputs({ [input]: 'TRUE' })[key], true)
+        })
       })
       t.test('TARGET', async t => {
         t.equal(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #363

We got little further with the initial GHES support, but it still hits with the verifySignatures:
```
Warning: PR contains invalid dependabot commit signatures, skipping.
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
