### PR TITLE
fix: typo in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,13 +47,13 @@ runs:
     - name: Fetch metadata
       id: dependabot-metadata
       uses: dependabot/fetch-metadata@v1
-      if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || skip-verification == 'true')
+      if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || inputs.skip-verification == 'true')
       with:
         skip-commit-verification: ${{ inputs.skip-commit-verification }}
         skip-verification :  ${{ inputs.skip-verification }}
     - name: Merge/approve PR
       uses: actions/github-script@v6
-      if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || skip-verification == 'true')
+      if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || inputs.skip-verification == 'true')
       with:
         github-token: ${{ inputs.github-token }}
         script: |


### PR DESCRIPTION
Accidental miss with #411  as parameters need to be accessed using `inputs`

This work is part of issue #378

