### PR TITLE
fix(priority): invert semver matching to avoid unfound semver

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2857,7 +2857,16 @@ module.exports = async function run({
 
     if (
       TARGET !== updateTypes.any &&
-      updateTypesPriority.indexOf(updateType) <
+      updateTypesPriority.indexOf(updateType) < 0
+    ) {
+      core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedInvalidVersion)
+      logWarning(`Semver bump '${updateType}' is invalid!`)
+      return
+    }
+
+    if (
+      TARGET !== updateTypes.any &&
+      updateTypesPriority.indexOf(updateType) >
         updateTypesPriority.indexOf(TARGET)
     ) {
       core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedBumpHigherThanTarget)
@@ -3080,10 +3089,10 @@ const updateTypes = {
 }
 
 const updateTypesPriority = [
-  updateTypes.any,
-  updateTypes.major,
-  updateTypes.minor,
   updateTypes.patch,
+  updateTypes.minor,
+  updateTypes.major,
+  updateTypes.any,
 ]
 
 const mapUpdateType = input => {
@@ -3165,6 +3174,7 @@ exports.MERGE_STATUS = {
   skippedCannotUpdateMajor: 'skipped:cannot_update_major',
   skippedBumpHigherThanTarget: 'skipped:bump_higher_than_target',
   skippedPackageExcluded: 'skipped:packaged_excluded',
+  skippedInvalidVersion: 'skipped:invalid_semver',
 }
 
 exports.MERGE_STATUS_KEY = 'merge_status'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2857,7 +2857,7 @@ module.exports = async function run({
 
     if (
       TARGET !== updateTypes.any &&
-      updateTypesPriority.indexOf(updateType) >
+      updateTypesPriority.indexOf(updateType) <
         updateTypesPriority.indexOf(TARGET)
     ) {
       core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedBumpHigherThanTarget)
@@ -3080,10 +3080,10 @@ const updateTypes = {
 }
 
 const updateTypesPriority = [
-  updateTypes.patch,
-  updateTypes.minor,
-  updateTypes.major,
   updateTypes.any,
+  updateTypes.major,
+  updateTypes.minor,
+  updateTypes.patch,
 ]
 
 const mapUpdateType = input => {
@@ -3314,7 +3314,7 @@ module.exports = require("util");
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"github-action-merge-dependabot","version":"3.9.0","description":"A GitHub action to automatically merge and approve Dependabot pull requests","main":"src/index.js","scripts":{"build":"ncc build src/index.js","lint":"eslint .","test":"tap test/**.test.js","prepare":"husky install"},"author":{"name":"Salman Mitha","email":"SalmanMitha@gmail.com"},"contributors":["Simone Busoli <simone.busoli@nearform.com>"],"license":"MIT","repository":{"type":"git","url":"git+https://github.com/fastify/github-action-merge-dependabot.git"},"bugs":{"url":"https://github.com/fastify/github-action-merge-dependabot/issues"},"homepage":"https://github.com/fastify/github-action-merge-dependabot#readme","dependencies":{"@actions/core":"^1.9.1","@actions/github":"^5.1.1","actions-toolkit":"github:nearform/actions-toolkit","gitdiff-parser":"^0.3.1","semver":"^7.5.2"},"devDependencies":{"@vercel/ncc":"^0.36.1","eslint":"^8.43.0","eslint-config-prettier":"^8.8.0","eslint-plugin-prettier":"^4.2.1","husky":"^8.0.3","prettier":"^2.8.8","proxyquire":"^2.1.3","sinon":"^15.1.2","tap":"^16.3.6"}}');
+module.exports = JSON.parse('{"name":"github-action-merge-dependabot","version":"3.9.0","description":"A GitHub action to automatically merge and approve Dependabot pull requests","main":"src/index.js","scripts":{"build":"ncc build src/index.js","lint":"eslint .","test":"tap test/**.test.js","prepare":"husky install"},"author":{"name":"Salman Mitha","email":"SalmanMitha@gmail.com"},"contributors":["Simone Busoli <simone.busoli@nearform.com>"],"license":"MIT","repository":{"type":"git","url":"git+https://github.com/fastify/github-action-merge-dependabot.git"},"bugs":{"url":"https://github.com/fastify/github-action-merge-dependabot/issues"},"homepage":"https://github.com/fastify/github-action-merge-dependabot#readme","dependencies":{"@actions/core":"^1.9.1","@actions/github":"^5.1.1","actions-toolkit":"github:nearform/actions-toolkit","gitdiff-parser":"^0.3.1","semver":"^7.5.4"},"devDependencies":{"@vercel/ncc":"^0.36.1","eslint":"^8.46.0","eslint-config-prettier":"^8.9.0","eslint-plugin-prettier":"^4.2.1","husky":"^8.0.3","prettier":"^2.8.8","proxyquire":"^2.1.3","sinon":"^15.2.0","tap":"^16.3.8"}}');
 
 /***/ })
 

--- a/src/action.js
+++ b/src/action.js
@@ -86,7 +86,16 @@ module.exports = async function run({
 
     if (
       TARGET !== updateTypes.any &&
-      updateTypesPriority.indexOf(updateType) <
+      updateTypesPriority.indexOf(updateType) < 0
+    ) {
+      core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedInvalidVersion)
+      logWarning(`Semver bump '${updateType}' is invalid!`)
+      return
+    }
+
+    if (
+      TARGET !== updateTypes.any &&
+      updateTypesPriority.indexOf(updateType) >
         updateTypesPriority.indexOf(TARGET)
     ) {
       core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedBumpHigherThanTarget)

--- a/src/action.js
+++ b/src/action.js
@@ -86,7 +86,7 @@ module.exports = async function run({
 
     if (
       TARGET !== updateTypes.any &&
-      updateTypesPriority.indexOf(updateType) >
+      updateTypesPriority.indexOf(updateType) <
         updateTypesPriority.indexOf(TARGET)
     ) {
       core.setOutput(MERGE_STATUS_KEY, MERGE_STATUS.skippedBumpHigherThanTarget)

--- a/src/mapUpdateType.js
+++ b/src/mapUpdateType.js
@@ -9,10 +9,10 @@ const updateTypes = {
 }
 
 const updateTypesPriority = [
-  updateTypes.any,
-  updateTypes.major,
-  updateTypes.minor,
   updateTypes.patch,
+  updateTypes.minor,
+  updateTypes.major,
+  updateTypes.any,
 ]
 
 const mapUpdateType = input => {

--- a/src/mapUpdateType.js
+++ b/src/mapUpdateType.js
@@ -9,10 +9,10 @@ const updateTypes = {
 }
 
 const updateTypesPriority = [
-  updateTypes.patch,
-  updateTypes.minor,
-  updateTypes.major,
   updateTypes.any,
+  updateTypes.major,
+  updateTypes.minor,
+  updateTypes.patch,
 ]
 
 const mapUpdateType = input => {

--- a/src/util.js
+++ b/src/util.js
@@ -60,6 +60,7 @@ exports.MERGE_STATUS = {
   skippedCannotUpdateMajor: 'skipped:cannot_update_major',
   skippedBumpHigherThanTarget: 'skipped:bump_higher_than_target',
   skippedPackageExcluded: 'skipped:packaged_excluded',
+  skippedInvalidVersion: 'skipped:invalid_semver',
 }
 
 exports.MERGE_STATUS_KEY = 'merge_status'


### PR DESCRIPTION
This PR is a fix suggestion.
fix #452 

#### Checklist

- [x] run `npm run test`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
