### PR TITLE
fix: "Fetch metadata" is skipped for "pull_request_target"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Fetch metadata
       id: dependabot-metadata
       uses: dependabot/fetch-metadata@v1
-      if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || inputs.skip-verification == 'true')
+      if: startsWith(github.event_name, 'pull_request') && (github.actor == 'dependabot[bot]' || inputs.skip-verification == 'true')
       with:
         skip-commit-verification: ${{ inputs.skip-commit-verification }}
         skip-verification :  ${{ inputs.skip-verification }}


### PR DESCRIPTION
The step `Fetch metadata` is skipped for a workflow triggered by the `pull_request_target`. The issue was found the first time approximately on the 28th of August. Before the date, there was no issue with the same workflow file. It seems something has been changed in GitHub Workflow implementation, but I couldn't find any evidence.

`dependabot-auto-merge.yml` content:

```
name: Dependabot
on: pull_request_target

permissions:
  contents: write
  pull-requests: write

jobs:
  Auto-merge:
    runs-on: ubuntu-latest

    steps:
      - uses: fastify/github-action-merge-dependabot@v3
        with:
          use-github-auto-merge: true
          target: minor
```

Fixes #475.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
