### PR TITLE
fix: suppress warning in ci/cd pipeline, add lint:fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "ncc build src/index.js",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "tap test/**.test.js",
     "prepare": "husky install"
   },

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,9 +1,16 @@
 'use strict'
 const tap = require('tap')
-const {
-  getInputs,
-  parseCommaOrSemicolonSeparatedValue,
-} = require('../src/util')
+const sinon = require('sinon')
+
+const logWarningStub = sinon.stub()
+const { getInputs, parseCommaOrSemicolonSeparatedValue } = tap.mockRequire(
+  '../src/util',
+  {
+    '../src/log.js': {
+      logWarning: logWarningStub,
+    },
+  }
+)
 
 tap.test('parseCommaOrSemicolonSeparatedValue', async t => {
   t.test('should split semicolon separated values correctly', async t => {
@@ -55,9 +62,15 @@ tap.test('getInputs', async t => {
       t.test('MERGE_METHOD', async t => {
         t.equal(getInputs({}).MERGE_METHOD, 'squash')
         t.equal(getInputs({ 'merge-method': 'merge' }).MERGE_METHOD, 'merge')
+        t.equal(logWarningStub.callCount, 0)
         t.equal(
           getInputs({ 'merge-method': 'invalid-merge-method' }).MERGE_METHOD,
           'squash'
+        )
+        t.equal(logWarningStub.callCount, 1)
+        t.equal(
+          logWarningStub.firstCall.args[0],
+          'merge-method input is ignored because it is malformed, defaulting to `squash`.'
         )
       })
       t.test('EXCLUDE_PKGS', async t => {


### PR DESCRIPTION
Removes the first warning, which is part of the unit tests

![image](https://github.com/fastify/github-action-merge-dependabot/assets/5059100/5e747f5c-cb48-4bf7-baaa-033129ca554e)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
