### PR TITLE
ci(.github): use latest node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setting action build runtime
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: 20
       - uses: nearform-actions/optic-release-automation-action@v4
         with:


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5577. This is a batch PR, so may have some issues. Please review changes.