### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/check-linked-issues.yml
+++ b/.github/workflows/check-linked-issues.yml
@@ -4,9 +4,15 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check_pull_requests:
     runs-on: ubuntu-latest
+    permissions:
+        issues: read
+        pull-requests: write
     name: Check linked issues
     steps:
       - uses: nearform-actions/github-action-check-linked-issues@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 on:
   push:
-    branches: main
+    branches: 
+      - main
   pull_request:
-    branches: main
+    branches: 
+      - main
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -5,9 +5,14 @@ on:
     types: [published]
   schedule:
     - cron: '30 8 * * *'
+permissions:
+  contents: read
 jobs:
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Notify release
         uses: nearform-actions/github-action-notify-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,16 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Setting action build runtime
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174.


This PR also sets `check-latest` to true, so that the `actions/setup-node` will check it is using the latest minor or hotfix Node version and use that instead of its cached version, this stops an issue like with 22.5.0 that introduced a regression and actions were still using that instead of 22.5.1