### PR TITLE
ci: pin third-party actions to commit-hash

### DIFF
--- a/.github/workflows/check-linked-issues.yml
+++ b/.github/workflows/check-linked-issues.yml
@@ -15,7 +15,7 @@ jobs:
         pull-requests: write
     name: Check linked issues
     steps:
-      - uses: nearform-actions/github-action-check-linked-issues@v1
+      - uses: nearform-actions/github-action-check-linked-issues@7140e2e01aa0c18b8ac61bddf5e89abde1ca760e # v1.8.3
         id: check-linked-issues
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Notify release
-        uses: nearform-actions/github-action-notify-release@v1
+        uses: nearform-actions/github-action-notify-release@1a1c03a2b8c9a41a7a88f9a8de05b2b6582f0966 # v1.12.2
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           check-latest: true
           node-version: 20
-      - uses: nearform-actions/optic-release-automation-action@v4
+      - uses: nearform-actions/optic-release-automation-action@0aab4e4c4f16472e358e2c697d14ea468258244c # v4.10.2
         with:
           github-token: ${{ github.token }}
           semver: ${{ github.event.inputs.semver }}


### PR DESCRIPTION
Closes https://github.com/fastify/github-action-merge-dependabot/security/code-scanning/5 and 3 other code scanning alerts.

Most first-party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes, but this is not available for third-party actions yet.