### PR TITLE
ci(ci): remove git credentials after checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           check-latest: true


### PR DESCRIPTION
This PR removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485).