### PR TITLE
refactor(action): avoid code injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           const { ACTION_PATH, UPDATE_TYPE, DEPENDENCY_TYPE, DEPENDENCY_NAMES } = process.env
-          const script = require('${ACTION_PATH}/dist/index.js')
+          const script = require(ACTION_PATH + '/dist/index.js')
           await script({
             github,
             context,

--- a/action.yml
+++ b/action.yml
@@ -68,18 +68,24 @@ runs:
     - name: Merge/approve PR
       uses: actions/github-script@v7
       id: approver
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
+        DEPENDENCY_TYPE: ${{ steps.dependabot-metadata.outputs.dependency-type }}
+        DEPENDENCY_NAMES: ${{ steps.dependabot-metadata.outputs.dependency-names }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const script = require('${{ github.action_path }}/dist/index.js')
+          const { ACTION_PATH, UPDATE_TYPE, DEPENDENCY_TYPE, DEPENDENCY_NAMES } = process.env
+          const script = require('${ACTION_PATH}/dist/index.js')
           await script({
             github,
             context,
             inputs: ${{ toJSON(inputs) }},
             dependabotMetadata: {
-              updateType:  '${{ steps.dependabot-metadata.outputs.update-type }}',
-              dependencyType:'${{ steps.dependabot-metadata.outputs.dependency-type }}',
-              dependencyNames: '${{ steps.dependabot-metadata.outputs.dependency-names }}',
+              updateType:  UPDATE_TYPE,
+              dependencyType: DEPENDENCY_TYPE,
+              dependencyNames: DEPENDENCY_NAMES,
             }
           })
 


### PR DESCRIPTION
The action contains code injection where values from external sources are directly interpolated into JavaScript code without proper sanitisation.

While these values come from the `dependabot/fetch-metadata` action rather than direct user input, they still represent external data that could potentially contain malicious content if the metadata action were compromised or if dependency names contained special characters that could break JavaScript syntax.

Closes https://github.com/fastify/github-action-merge-dependabot/security/code-scanning/9, https://github.com/fastify/github-action-merge-dependabot/security/code-scanning/8, https://github.com/fastify/github-action-merge-dependabot/security/code-scanning/7, and https://github.com/fastify/github-action-merge-dependabot/security/code-scanning/6.