### PR TITLE
refactor(action): pin dependencies with full SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,13 +60,13 @@ runs:
   steps:
     - name: Fetch metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v2
+      uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
       if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || inputs.skip-verification == 'true')
       with:
         skip-commit-verification: ${{ inputs.skip-commit-verification }}
         skip-verification: ${{ inputs.skip-verification }}
     - name: Merge/approve PR
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       id: approver
       env:
         ACTION_PATH: ${{ github.action_path }}


### PR DESCRIPTION
## Context

When enabling new GitHub policy to force pinning of actions with full SHA this break the automerge workflow.

<img width="772" height="580" alt="image" src="https://github.com/user-attachments/assets/25212b64-e690-45b6-80fc-a589ee353ef4" />

<img width="1225" height="288" alt="image" src="https://github.com/user-attachments/assets/f59ad30a-4d64-42a2-9804-1f5272717e51" />

This PR pin dependencies in `action.yml`

Note: a 3.0.0 is available for dependabot/fetch-metadata but I didn't want to risk a breaking here.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
